### PR TITLE
fix: ignore heartbeat monitorings in instance runner

### DIFF
--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -11,10 +11,11 @@ import (
 type Type string
 
 const (
-	TypeHTTP    Type = "http"
-	TypePing    Type = "ping"
-	TypeKeyword Type = "keyword"
-	TypePort    Type = "port"
+	TypeHTTP      Type = "http"
+	TypePing      Type = "ping"
+	TypeKeyword   Type = "keyword"
+	TypePort      Type = "port"
+	TypeHeartbeat Type = "heartbeat"
 )
 
 type Status string
@@ -53,6 +54,10 @@ type Monitoring struct {
 	Keyword string `json:"keyword"`
 	Port    int    `json:"port"`
 
+	HeartbeatIntervalMinutes *int       `json:"heartbeat_interval_minutes"`
+	HeartbeatGraceMinutes    *int       `json:"heartbeat_grace_minutes"`
+	HeartbeatLastPingAt      *time.Time `json:"heartbeat_last_ping_at"`
+
 	MaintenanceActive bool `json:"maintenance_active"`
 }
 
@@ -76,6 +81,10 @@ func (m *Monitoring) UnmarshalJSON(data []byte) error {
 		Keyword string `json:"keyword"`
 		Port    any    `json:"port"`
 
+		HeartbeatIntervalMinutes any `json:"heartbeat_interval_minutes"`
+		HeartbeatGraceMinutes    any `json:"heartbeat_grace_minutes"`
+		HeartbeatLastPingAt      any `json:"heartbeat_last_ping_at"`
+
 		MaintenanceActive any `json:"maintenance_active"`
 	}
 
@@ -94,6 +103,18 @@ func (m *Monitoring) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	port, err := parseIntFlexible(raw.Port, "port")
+	if err != nil {
+		return err
+	}
+	heartbeatIntervalMinutes, err := parseOptionalIntFlexible(raw.HeartbeatIntervalMinutes, "heartbeat_interval_minutes")
+	if err != nil {
+		return err
+	}
+	heartbeatGraceMinutes, err := parseOptionalIntFlexible(raw.HeartbeatGraceMinutes, "heartbeat_grace_minutes")
+	if err != nil {
+		return err
+	}
+	heartbeatLastPingAt, err := parseTimeFlexible(raw.HeartbeatLastPingAt, "heartbeat_last_ping_at")
 	if err != nil {
 		return err
 	}
@@ -119,6 +140,10 @@ func (m *Monitoring) UnmarshalJSON(data []byte) error {
 
 		Keyword: raw.Keyword,
 		Port:    port,
+
+		HeartbeatIntervalMinutes: heartbeatIntervalMinutes,
+		HeartbeatGraceMinutes:    heartbeatGraceMinutes,
+		HeartbeatLastPingAt:      heartbeatLastPingAt,
 
 		MaintenanceActive: maintenanceActive,
 	}
@@ -197,6 +222,41 @@ func parseIntFlexible(value any, field string) (int, error) {
 		return 0, err
 	}
 	return int(parsed), nil
+}
+
+func parseOptionalIntFlexible(value any, field string) (*int, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	parsed, err := parseIntFlexible(value, field)
+	if err != nil {
+		return nil, err
+	}
+
+	return &parsed, nil
+}
+
+func parseTimeFlexible(value any, field string) (*time.Time, error) {
+	switch typed := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed == "" {
+			return nil, nil
+		}
+		parsed, err := time.Parse(time.RFC3339Nano, trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("invalid %s: %w", field, err)
+		}
+		return &parsed, nil
+	case time.Time:
+		parsed := typed.UTC()
+		return &parsed, nil
+	default:
+		return nil, fmt.Errorf("invalid %s type: %T", field, value)
+	}
 }
 
 func parseBoolFlexible(value any, field string) (bool, error) {

--- a/internal/monitor/types_test.go
+++ b/internal/monitor/types_test.go
@@ -3,6 +3,7 @@ package monitor
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func TestMonitoringUnmarshalWithNumericID(t *testing.T) {
@@ -66,5 +67,37 @@ func TestMonitoringUnmarshalWithInvalidID(t *testing.T) {
 	}`), &monitoring)
 	if err == nil {
 		t.Fatalf("expected error for invalid id")
+	}
+}
+
+func TestMonitoringUnmarshalHeartbeatMonitoring(t *testing.T) {
+	t.Parallel()
+
+	var monitoring Monitoring
+	err := json.Unmarshal([]byte(`{
+		"id": "hb-42",
+		"type": "heartbeat",
+		"target": "scheduler:nightly-job",
+		"heartbeat_interval_minutes": "15",
+		"heartbeat_grace_minutes": 5,
+		"heartbeat_last_ping_at": "2026-04-18T10:15:00Z",
+		"maintenance_active": false
+	}`), &monitoring)
+	if err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if monitoring.Type != TypeHeartbeat {
+		t.Fatalf("expected type heartbeat, got %s", monitoring.Type)
+	}
+	if monitoring.HeartbeatIntervalMinutes == nil || *monitoring.HeartbeatIntervalMinutes != 15 {
+		t.Fatalf("expected heartbeat_interval_minutes=15, got %#v", monitoring.HeartbeatIntervalMinutes)
+	}
+	if monitoring.HeartbeatGraceMinutes == nil || *monitoring.HeartbeatGraceMinutes != 5 {
+		t.Fatalf("expected heartbeat_grace_minutes=5, got %#v", monitoring.HeartbeatGraceMinutes)
+	}
+	expectedLastPingAt := time.Date(2026, 4, 18, 10, 15, 0, 0, time.UTC)
+	if monitoring.HeartbeatLastPingAt == nil || !monitoring.HeartbeatLastPingAt.Equal(expectedLastPingAt) {
+		t.Fatalf("expected heartbeat_last_ping_at=%s, got %#v", expectedLastPingAt, monitoring.HeartbeatLastPingAt)
 	}
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -35,6 +35,19 @@ var pingLatencyPattern = regexp.MustCompile(`time[=<]([0-9]+(?:\.[0-9]+)?)\s*ms`
 
 var pingExecutor = runPingCommand
 
+var responseMonitoringTypes = []monitor.Type{
+	monitor.TypeHTTP,
+	monitor.TypePing,
+	monitor.TypeKeyword,
+	monitor.TypePort,
+}
+
+var sslMonitoringTypes = []monitor.Type{
+	monitor.TypeHTTP,
+	monitor.TypeKeyword,
+	monitor.TypePort,
+}
+
 type CoreClient interface {
 	GetMonitorings(ctx context.Context, location string, types []monitor.Type) ([]monitor.Monitoring, error)
 	PostMonitoringResponse(ctx context.Context, payload monitor.MonitoringResponsePayload) error
@@ -61,7 +74,7 @@ func New(client CoreClient, cfg config.Config, logger *log.Logger) *Runner {
 func (r *Runner) runResponse(ctx context.Context) error {
 	r.logger.Println("Dispatching response monitoring jobs...")
 
-	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, nil)
+	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, responseMonitoringTypes)
 	if err != nil {
 		r.logFetchError(err)
 		return err
@@ -74,6 +87,7 @@ func (r *Runner) runResponse(ctx context.Context) error {
 
 	dispatched := 0
 	skippedMaintenance := 0
+	skippedUnsupported := 0
 
 	jobs := make(chan monitor.Monitoring)
 	var workers sync.WaitGroup
@@ -106,6 +120,16 @@ func (r *Runner) runResponse(ctx context.Context) error {
 	}
 
 	for _, monitoring := range monitorings {
+		if !supportsResponseChecks(monitoring.Type) {
+			skippedUnsupported++
+			r.logger.Printf(
+				"Skipping passive/unsupported response monitoring (monitoring_id=%s type=%s)",
+				monitoring.ID,
+				monitoring.Type,
+			)
+			continue
+		}
+
 		if monitoring.MaintenanceActive {
 			skippedMaintenance++
 			if err := r.client.PostMonitoringResponse(ctx, monitor.MonitoringResponsePayload{
@@ -126,10 +150,11 @@ func (r *Runner) runResponse(ctx context.Context) error {
 	workers.Wait()
 
 	r.logger.Printf(
-		"Response monitoring dispatch done. total=%d dispatched=%d skipped_maintenance=%d",
+		"Response monitoring dispatch done. total=%d dispatched=%d skipped_maintenance=%d skipped_unsupported=%d",
 		len(monitorings),
 		dispatched,
 		skippedMaintenance,
+		skippedUnsupported,
 	)
 
 	return nil
@@ -138,8 +163,7 @@ func (r *Runner) runResponse(ctx context.Context) error {
 func (r *Runner) runSSL(ctx context.Context) error {
 	r.logger.Println("Dispatching SSL monitoring jobs...")
 
-	types := []monitor.Type{monitor.TypeHTTP, monitor.TypeKeyword, monitor.TypePort}
-	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, types)
+	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, sslMonitoringTypes)
 	if err != nil {
 		r.logFetchError(err)
 		return err
@@ -152,6 +176,7 @@ func (r *Runner) runSSL(ctx context.Context) error {
 
 	dispatched := 0
 	skippedMaintenance := 0
+	skippedUnsupported := 0
 
 	jobs := make(chan monitor.Monitoring)
 	var workers sync.WaitGroup
@@ -171,6 +196,16 @@ func (r *Runner) runSSL(ctx context.Context) error {
 	}
 
 	for _, monitoring := range monitorings {
+		if !supportsSSLChecks(monitoring.Type) {
+			skippedUnsupported++
+			r.logger.Printf(
+				"Skipping passive/unsupported SSL monitoring (monitoring_id=%s type=%s)",
+				monitoring.ID,
+				monitoring.Type,
+			)
+			continue
+		}
+
 		if monitoring.MaintenanceActive {
 			skippedMaintenance++
 			continue
@@ -182,10 +217,11 @@ func (r *Runner) runSSL(ctx context.Context) error {
 	workers.Wait()
 
 	r.logger.Printf(
-		"SSL monitoring dispatch done. total=%d dispatched=%d skipped_maintenance=%d",
+		"SSL monitoring dispatch done. total=%d dispatched=%d skipped_maintenance=%d skipped_unsupported=%d",
 		len(monitorings),
 		dispatched,
 		skippedMaintenance,
+		skippedUnsupported,
 	)
 
 	return nil
@@ -243,8 +279,28 @@ func (r *Runner) crawlResponseMonitoring(ctx context.Context, monitoring monitor
 	case monitor.TypePort:
 		status, responseTime := handlePortMonitoring(monitoring)
 		return status, responseTime, nil
+	case monitor.TypeHeartbeat:
+		return monitor.StatusUnknown, nil, nil
 	default:
 		return monitor.StatusUnknown, nil, nil
+	}
+}
+
+func supportsResponseChecks(monitoringType monitor.Type) bool {
+	switch monitoringType {
+	case monitor.TypeHTTP, monitor.TypePing, monitor.TypeKeyword, monitor.TypePort:
+		return true
+	default:
+		return false
+	}
+}
+
+func supportsSSLChecks(monitoringType monitor.Type) bool {
+	switch monitoringType {
+	case monitor.TypeHTTP, monitor.TypeKeyword, monitor.TypePort:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/runner/runner_logic_test.go
+++ b/internal/runner/runner_logic_test.go
@@ -475,6 +475,7 @@ func TestRunSSLPostsResults(t *testing.T) {
 		sslMonitorings: []monitor.Monitoring{
 			{
 				ID:     "3",
+				Type:   monitor.TypeHTTP,
 				Target: "https://127.0.0.1:" + strconv.Itoa(1),
 			},
 		},

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,11 +1,13 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -39,7 +41,7 @@ func (f *fakeCoreClient) GetMonitorings(_ context.Context, location string, type
 	})
 	f.mu.Unlock()
 
-	if len(types) == 0 {
+	if len(types) == len(responseMonitoringTypes) {
 		return append([]monitor.Monitoring(nil), f.responseMonitorings...), nil
 	}
 
@@ -72,6 +74,12 @@ func (f *fakeCoreClient) snapshotPostedResponses() []monitor.MonitoringResponseP
 	return append([]monitor.MonitoringResponsePayload(nil), f.postedResponses...)
 }
 
+func (f *fakeCoreClient) snapshotPostedSSL() []monitor.SSLResultPayload {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]monitor.SSLResultPayload(nil), f.postedSSL...)
+}
+
 func TestRunMonitoringMaintenancePostsUnknown(t *testing.T) {
 	t.Parallel()
 
@@ -79,6 +87,7 @@ func TestRunMonitoringMaintenancePostsUnknown(t *testing.T) {
 		responseMonitorings: []monitor.Monitoring{
 			{
 				ID:                "7",
+				Type:              monitor.TypeHTTP,
 				MaintenanceActive: true,
 			},
 		},
@@ -107,7 +116,11 @@ func TestRunMonitoringMaintenancePostsUnknown(t *testing.T) {
 			t.Fatalf("expected location de-1, got %q", call.location)
 		}
 
-		if len(call.types) == 0 {
+		if len(call.types) == 4 &&
+			call.types[0] == monitor.TypeHTTP &&
+			call.types[1] == monitor.TypePing &&
+			call.types[2] == monitor.TypeKeyword &&
+			call.types[3] == monitor.TypePort {
 			foundResponseFetch = true
 			continue
 		}
@@ -176,6 +189,13 @@ func TestRunMonitoringRequestsNonPingTypesForSSL(t *testing.T) {
 		if call.location != "us-1" {
 			t.Fatalf("expected location us-1, got %q", call.location)
 		}
+		if len(call.types) == 4 &&
+			call.types[0] == monitor.TypeHTTP &&
+			call.types[1] == monitor.TypePing &&
+			call.types[2] == monitor.TypeKeyword &&
+			call.types[3] == monitor.TypePort {
+			continue
+		}
 		if len(call.types) == 3 &&
 			call.types[0] == monitor.TypeHTTP &&
 			call.types[1] == monitor.TypeKeyword &&
@@ -186,6 +206,51 @@ func TestRunMonitoringRequestsNonPingTypesForSSL(t *testing.T) {
 
 	if !foundSSLFetch {
 		t.Fatalf("ssl types fetch missing")
+	}
+}
+
+func TestRunMonitoringSkipsHeartbeatMonitoringsWithoutPostingResults(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeCoreClient{
+		responseMonitorings: []monitor.Monitoring{
+			{
+				ID:   "hb-response",
+				Type: monitor.TypeHeartbeat,
+			},
+		},
+		sslMonitorings: []monitor.Monitoring{
+			{
+				ID:   "hb-ssl",
+				Type: monitor.TypeHeartbeat,
+			},
+		},
+	}
+
+	var logs bytes.Buffer
+	cfg := config.Config{
+		WebGuardLocation:    "de-1",
+		QueueDefaultWorkers: 1,
+	}
+	runner := New(client, cfg, log.New(&logs, "", 0))
+
+	if err := runner.RunMonitoring(context.Background()); err != nil {
+		t.Fatalf("RunMonitoring failed: %v", err)
+	}
+
+	if postedResponses := client.snapshotPostedResponses(); len(postedResponses) != 0 {
+		t.Fatalf("expected no posted response payloads, got %d", len(postedResponses))
+	}
+	if postedSSL := client.snapshotPostedSSL(); len(postedSSL) != 0 {
+		t.Fatalf("expected no posted ssl payloads, got %d", len(postedSSL))
+	}
+
+	logOutput := logs.String()
+	if !strings.Contains(logOutput, "Skipping passive/unsupported response monitoring (monitoring_id=hb-response type=heartbeat)") {
+		t.Fatalf("expected response skip log, got %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "Skipping passive/unsupported SSL monitoring (monitoring_id=hb-ssl type=heartbeat)") {
+		t.Fatalf("expected ssl skip log, got %q", logOutput)
 	}
 }
 
@@ -258,9 +323,9 @@ type parallelPhasesClient struct {
 }
 
 func (p *parallelPhasesClient) GetMonitorings(_ context.Context, _ string, types []monitor.Type) ([]monitor.Monitoring, error) {
-	phase := "response"
-	if len(types) > 0 {
-		phase = "ssl"
+	phase := "ssl"
+	if len(types) == len(responseMonitoringTypes) {
+		phase = "response"
 	}
 	p.started <- phase
 	<-p.release


### PR DESCRIPTION
## Summary
- add `heartbeat` as a known monitoring type and parse optional heartbeat fields from core payloads
- restrict active fetch/execution to monitorings the instance can actually check and skip passive heartbeat payloads with explicit logging
- add tests for heartbeat parsing, scheduler/executor skip behavior, and avoiding response/ssl writes for heartbeat monitorings

## Why
`webguard-core` now manages heartbeat monitoring end to end. The instance must stay compatible when heartbeat payloads appear, but it must not execute checks or send response/SSL results for them.

## Impact
Heartbeat monitorings no longer cause deserialization/runtime issues in the instance, and existing active monitoring types keep their current execution path.

## Validation
- `go test ./...`