### PR TITLE
Add domain expiration monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ It is built to stay compatible with the current core integration while improving
   - `GET /api/v1/internal/monitorings`
   - `POST /api/v1/internal/monitoring-responses`
   - `POST /api/v1/internal/ssl-results`
+  - `POST /api/v1/internal/domain-results`
   - `X-INSTANCE-CODE` + `X-API-KEY` header authentication
 - **Parallel Monitoring Execution**
-  - Response and SSL phases run in parallel
+  - Response, SSL, and domain expiration phases run in parallel
   - Worker-based parallel processing for monitoring jobs
 - **Simple Operations**
   - Docker-first local and production setup

--- a/internal/core/client.go
+++ b/internal/core/client.go
@@ -127,6 +127,15 @@ func (c *Client) PostSSLResult(ctx context.Context, payload monitor.SSLResultPay
 	return c.doJSON(request, nil)
 }
 
+func (c *Client) PostDomainResult(ctx context.Context, payload monitor.DomainResultPayload) error {
+	request, err := c.newRequest(ctx, http.MethodPost, "/api/v1/internal/domain-results", nil, payload)
+	if err != nil {
+		return err
+	}
+
+	return c.doJSON(request, nil)
+}
+
 func (c *Client) newRequest(ctx context.Context, method, path string, query url.Values, body any) (*http.Request, error) {
 	if c.baseURL == "" {
 		return nil, fmt.Errorf("WEBGUARD_CORE_API_URL is empty")

--- a/internal/core/client_test.go
+++ b/internal/core/client_test.go
@@ -273,6 +273,59 @@ func TestPostSSLResultPayloadShape(t *testing.T) {
 	}
 }
 
+func TestPostDomainResultPayloadShape(t *testing.T) {
+	t.Parallel()
+
+	var gotInstanceCode string
+	var body map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/internal/domain-results" {
+			t.Fatalf("unexpected path: %s", request.URL.Path)
+		}
+
+		gotInstanceCode = request.Header.Get("X-INSTANCE-CODE")
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "secret-key", "de-1")
+	now := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	expiresAt := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	err := client.PostDomainResult(context.Background(), monitor.DomainResultPayload{
+		MonitoringID: "domain-1",
+		IsValid:      true,
+		ExpiresAt:    &expiresAt,
+		Registrar:    ptr("Example Registrar"),
+		CheckedAt:    now,
+	})
+	if err != nil {
+		t.Fatalf("PostDomainResult failed: %v", err)
+	}
+
+	if gotInstanceCode != "de-1" {
+		t.Fatalf("expected instance code de-1, got %q", gotInstanceCode)
+	}
+	if body["monitoring_id"] != "domain-1" {
+		t.Fatalf("expected monitoring_id=domain-1, got %#v", body["monitoring_id"])
+	}
+	if body["is_valid"] != true {
+		t.Fatalf("expected is_valid=true, got %#v", body["is_valid"])
+	}
+	if body["registrar"] != "Example Registrar" {
+		t.Fatalf("expected registrar=Example Registrar, got %#v", body["registrar"])
+	}
+	if body["expires_at"] != "2026-07-23T12:00:00Z" {
+		t.Fatalf("expected expires_at RFC3339, got %#v", body["expires_at"])
+	}
+	if body["checked_at"] != "2026-04-24T12:00:00Z" {
+		t.Fatalf("expected checked_at RFC3339, got %#v", body["checked_at"])
+	}
+}
+
 func TestGetMonitoringsReturnsStatusError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/domainlookup/domainlookup.go
+++ b/internal/domainlookup/domainlookup.go
@@ -1,0 +1,451 @@
+package domainlookup
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const defaultRDAPBaseURL = "https://rdap.org/domain/"
+
+var (
+	expirationFieldPattern = regexp.MustCompile(`(?i)^\s*(registry expiry date|registrar registration expiration date|expiration date|paid-till|expiry date)\s*:\s*(.+?)\s*$`)
+	registrarFieldPattern  = regexp.MustCompile(`(?i)^\s*(registrar|sponsoring registrar)\s*:\s*(.+?)\s*$`)
+	whoisReferralPattern   = regexp.MustCompile(`(?i)^\s*refer:\s*(\S+)\s*$`)
+)
+
+type TemporaryError struct {
+	Err error
+}
+
+func (e *TemporaryError) Error() string {
+	if e.Err == nil {
+		return "temporary domain lookup failure"
+	}
+	return e.Err.Error()
+}
+
+func (e *TemporaryError) Unwrap() error {
+	return e.Err
+}
+
+func IsTemporary(err error) bool {
+	var temporary *TemporaryError
+	return errors.As(err, &temporary)
+}
+
+type Result struct {
+	Domain     string
+	Registered bool
+	ExpiresAt  *time.Time
+	Registrar  *string
+	CheckedAt  time.Time
+}
+
+type Lookup struct {
+	httpClient  *http.Client
+	dialer      *net.Dialer
+	rdapBaseURL string
+}
+
+func New(timeout time.Duration) *Lookup {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &Lookup{
+		httpClient:  &http.Client{Timeout: timeout},
+		dialer:      &net.Dialer{Timeout: timeout},
+		rdapBaseURL: defaultRDAPBaseURL,
+	}
+}
+
+func (l *Lookup) Lookup(ctx context.Context, target string) (Result, error) {
+	domain := NormalizeTarget(target)
+	checkedAt := time.Now().UTC()
+	result := Result{
+		Domain:    domain,
+		CheckedAt: checkedAt,
+	}
+	if domain == "" || strings.Contains(domain, "/") {
+		return result, nil
+	}
+
+	var temporaryErr error
+	for _, candidate := range lookupCandidates(domain) {
+		candidateResult, err := l.lookupCandidate(ctx, candidate, checkedAt)
+		if err != nil {
+			if IsTemporary(err) && temporaryErr == nil {
+				temporaryErr = err
+			}
+			continue
+		}
+		if candidateResult.Registered {
+			return candidateResult, nil
+		}
+	}
+
+	if temporaryErr != nil {
+		return result, &TemporaryError{Err: temporaryErr}
+	}
+
+	return result, nil
+}
+
+func (l *Lookup) lookupCandidate(ctx context.Context, domain string, checkedAt time.Time) (Result, error) {
+	result := Result{
+		Domain:    domain,
+		CheckedAt: checkedAt,
+	}
+
+	rdapResult, rdapErr := l.lookupRDAP(ctx, domain, checkedAt)
+	if rdapErr == nil && (!rdapResult.Registered || rdapResult.ExpiresAt != nil) {
+		return rdapResult, nil
+	}
+
+	whoisResult, whoisErr := l.lookupWHOIS(ctx, domain, checkedAt)
+	if whoisErr == nil {
+		if whoisResult.Registered {
+			if whoisResult.Registrar == nil {
+				whoisResult.Registrar = rdapResult.Registrar
+			}
+			return whoisResult, nil
+		}
+		if rdapErr == nil && rdapResult.Registered {
+			return rdapResult, nil
+		}
+		if IsTemporary(rdapErr) {
+			return result, &TemporaryError{Err: rdapErr}
+		}
+		if whoisResult.Registrar == nil {
+			whoisResult.Registrar = rdapResult.Registrar
+		}
+		return whoisResult, nil
+	}
+
+	if rdapErr == nil && rdapResult.Registered {
+		return rdapResult, nil
+	}
+	if IsTemporary(rdapErr) || IsTemporary(whoisErr) {
+		return result, &TemporaryError{Err: firstError(rdapErr, whoisErr)}
+	}
+
+	return result, nil
+}
+
+func NormalizeTarget(target string) string {
+	return strings.Trim(strings.TrimSpace(strings.ToLower(target)), ".")
+}
+
+func (l *Lookup) lookupRDAP(ctx context.Context, domain string, checkedAt time.Time) (Result, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, l.rdapBaseURL+domain, nil)
+	if err != nil {
+		return Result{Domain: domain, CheckedAt: checkedAt}, err
+	}
+	request.Header.Set("Accept", "application/rdap+json, application/json")
+
+	response, err := l.httpClient.Do(request)
+	if err != nil {
+		return Result{Domain: domain, CheckedAt: checkedAt}, &TemporaryError{Err: err}
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusNotFound {
+		return Result{Domain: domain, CheckedAt: checkedAt}, nil
+	}
+	if response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError {
+		return Result{Domain: domain, CheckedAt: checkedAt}, &TemporaryError{Err: fmt.Errorf("rdap returned status %d", response.StatusCode)}
+	}
+	if response.StatusCode >= http.StatusBadRequest {
+		return Result{Domain: domain, CheckedAt: checkedAt}, fmt.Errorf("rdap returned status %d", response.StatusCode)
+	}
+
+	var payload rdapDomainResponse
+	if err := json.NewDecoder(io.LimitReader(response.Body, 2<<20)).Decode(&payload); err != nil {
+		return Result{Domain: domain, CheckedAt: checkedAt}, err
+	}
+
+	expiresAt := parseRDAPExpiration(payload.Events)
+	registrar := parseRDAPRegistrar(payload.Entities)
+	return Result{
+		Domain:     domain,
+		Registered: true,
+		ExpiresAt:  expiresAt,
+		Registrar:  registrar,
+		CheckedAt:  checkedAt,
+	}, nil
+}
+
+func (l *Lookup) lookupWHOIS(ctx context.Context, domain string, checkedAt time.Time) (Result, error) {
+	server, err := l.lookupWHOISServer(ctx, tld(domain))
+	if err != nil {
+		return Result{Domain: domain, CheckedAt: checkedAt}, err
+	}
+	if server == "" {
+		return Result{Domain: domain, CheckedAt: checkedAt}, nil
+	}
+
+	raw, err := l.queryWHOIS(ctx, server, domain)
+	if err != nil {
+		return Result{Domain: domain, CheckedAt: checkedAt}, &TemporaryError{Err: err}
+	}
+	if looksUnavailable(raw) {
+		return Result{Domain: domain, CheckedAt: checkedAt}, nil
+	}
+
+	expiresAt, registrar := ParseWHOIS(raw)
+	return Result{
+		Domain:     domain,
+		Registered: true,
+		ExpiresAt:  expiresAt,
+		Registrar:  registrar,
+		CheckedAt:  checkedAt,
+	}, nil
+}
+
+func (l *Lookup) lookupWHOISServer(ctx context.Context, tld string) (string, error) {
+	if tld == "" {
+		return "", nil
+	}
+	raw, err := l.queryWHOIS(ctx, "whois.iana.org", tld)
+	if err != nil {
+		return "", &TemporaryError{Err: err}
+	}
+	matches := whoisReferralPattern.FindStringSubmatch(raw)
+	if len(matches) < 2 {
+		return "", nil
+	}
+	return strings.TrimSpace(matches[1]), nil
+}
+
+func (l *Lookup) queryWHOIS(ctx context.Context, server, query string) (string, error) {
+	var dialer net.Dialer
+	if l.dialer != nil {
+		dialer = *l.dialer
+	}
+
+	connection, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(server, "43"))
+	if err != nil {
+		return "", err
+	}
+	defer connection.Close()
+
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = connection.SetDeadline(deadline)
+	} else if dialer.Timeout > 0 {
+		_ = connection.SetDeadline(time.Now().Add(dialer.Timeout))
+	}
+
+	if _, err := fmt.Fprintf(connection, "%s\r\n", query); err != nil {
+		return "", err
+	}
+	response, err := io.ReadAll(io.LimitReader(connection, 2<<20))
+	if err != nil {
+		return "", err
+	}
+	return string(response), nil
+}
+
+type rdapDomainResponse struct {
+	Events   []rdapEvent  `json:"events"`
+	Entities []rdapEntity `json:"entities"`
+}
+
+type rdapEvent struct {
+	EventAction string `json:"eventAction"`
+	EventDate   string `json:"eventDate"`
+}
+
+type rdapEntity struct {
+	Roles      []string `json:"roles"`
+	VCardArray []any    `json:"vcardArray"`
+}
+
+func parseRDAPExpiration(events []rdapEvent) *time.Time {
+	for _, event := range events {
+		action := strings.ToLower(strings.TrimSpace(event.EventAction))
+		if action != "expiration" && action != "expiry" && action != "registration expiration" {
+			continue
+		}
+		parsed, err := parseDate(event.EventDate)
+		if err == nil {
+			return &parsed
+		}
+	}
+	return nil
+}
+
+func parseRDAPRegistrar(entities []rdapEntity) *string {
+	for _, entity := range entities {
+		if !hasRole(entity.Roles, "registrar") {
+			continue
+		}
+		if registrar := parseVCardFN(entity.VCardArray); registrar != nil {
+			return registrar
+		}
+	}
+	return nil
+}
+
+func hasRole(roles []string, role string) bool {
+	for _, item := range roles {
+		if strings.EqualFold(strings.TrimSpace(item), role) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseVCardFN(vcard []any) *string {
+	if len(vcard) < 2 {
+		return nil
+	}
+	properties, ok := vcard[1].([]any)
+	if !ok {
+		return nil
+	}
+	for _, rawProperty := range properties {
+		property, ok := rawProperty.([]any)
+		if !ok || len(property) < 4 {
+			continue
+		}
+		name, ok := property[0].(string)
+		if !ok || !strings.EqualFold(name, "fn") {
+			continue
+		}
+		value, ok := property[3].(string)
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return &value
+		}
+	}
+	return nil
+}
+
+func ParseWHOIS(raw string) (*time.Time, *string) {
+	var expiresAt *time.Time
+	var registrar *string
+
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if matches := expirationFieldPattern.FindStringSubmatch(line); len(matches) == 3 {
+			if parsed, err := parseDate(cleanDateValue(matches[2])); err == nil {
+				if expiresAt == nil || parsed.Before(*expiresAt) {
+					value := parsed
+					expiresAt = &value
+				}
+			}
+			continue
+		}
+		if registrar == nil {
+			if matches := registrarFieldPattern.FindStringSubmatch(line); len(matches) == 3 {
+				value := strings.TrimSpace(matches[2])
+				if value != "" {
+					registrar = &value
+				}
+			}
+		}
+	}
+
+	return expiresAt, registrar
+}
+
+func cleanDateValue(value string) string {
+	value = strings.TrimSpace(value)
+	value = strings.TrimSuffix(value, ".")
+	if index := strings.Index(value, " ("); index >= 0 {
+		value = strings.TrimSpace(value[:index])
+	}
+	return value
+}
+
+func parseDate(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, fmt.Errorf("empty date")
+	}
+
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05-0700",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05 MST",
+		"2006-01-02 15:04:05 -0700",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+		"02-Jan-2006",
+		"02-Jan-2006 15:04:05 MST",
+		"2006.01.02",
+		"02.01.2006",
+		"January 2 2006",
+		"2 January 2006",
+	}
+	for _, layout := range layouts {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			return parsed.UTC(), nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("unsupported date format: %s", value)
+}
+
+func looksUnavailable(raw string) bool {
+	normalized := strings.ToLower(raw)
+	unavailableMarkers := []string{
+		"no match for",
+		"not found",
+		"no data found",
+		"no entries found",
+		"status: free",
+		"domain not found",
+	}
+	for _, marker := range unavailableMarkers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func tld(domain string) string {
+	parts := strings.Split(domain, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+func lookupCandidates(domain string) []string {
+	parts := strings.Split(domain, ".")
+	if len(parts) <= 2 {
+		return []string{domain}
+	}
+
+	candidates := make([]string, 0, len(parts)-1)
+	for i := 0; i <= len(parts)-2; i++ {
+		candidates = append(candidates, strings.Join(parts[i:], "."))
+	}
+	return candidates
+}
+
+func firstError(errors ...error) error {
+	for _, err := range errors {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/domainlookup/domainlookup_test.go
+++ b/internal/domainlookup/domainlookup_test.go
@@ -1,0 +1,98 @@
+package domainlookup
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestNormalizeTarget(t *testing.T) {
+	t.Parallel()
+
+	got := NormalizeTarget(" Example.COM. ")
+	if got != "example.com" {
+		t.Fatalf("expected normalized domain example.com, got %q", got)
+	}
+}
+
+func TestLookupCandidatesIncludeParentDomains(t *testing.T) {
+	t.Parallel()
+
+	got := lookupCandidates("subdomain.example.com")
+	expected := []string{"subdomain.example.com", "example.com"}
+	if !reflect.DeepEqual(got, expected) {
+		t.Fatalf("unexpected candidates: got %#v want %#v", got, expected)
+	}
+}
+
+func TestParseWHOISExpirationFormats(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		whois    string
+		expected time.Time
+	}{
+		{
+			name:     "registry expiry rfc3339",
+			whois:    "Registry Expiry Date: 2026-07-23T12:00:00Z\nRegistrar: Example Registrar",
+			expected: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "registrar registration expiration with timezone",
+			whois:    "Registrar Registration Expiration Date: 2026-07-23 12:00:00 UTC",
+			expected: time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "expiration date day month",
+			whois:    "Expiration Date: 23-Jul-2026",
+			expected: time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "paid till dotted",
+			whois:    "paid-till: 2026.07.23",
+			expected: time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "expiry date iso day",
+			whois:    "Expiry Date: 2026-07-23",
+			expected: time.Date(2026, 7, 23, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			expiresAt, registrar := ParseWHOIS(testCase.whois)
+			if expiresAt == nil {
+				t.Fatalf("expected expiration date")
+			}
+			if !expiresAt.Equal(testCase.expected) {
+				t.Fatalf("expected expiration %s, got %s", testCase.expected, *expiresAt)
+			}
+			if testCase.name == "registry expiry rfc3339" {
+				if registrar == nil || *registrar != "Example Registrar" {
+					t.Fatalf("expected registrar Example Registrar, got %#v", registrar)
+				}
+			}
+		})
+	}
+}
+
+func TestParseWHOISUsesEarliestExpirationDate(t *testing.T) {
+	t.Parallel()
+
+	expiresAt, _ := ParseWHOIS(`
+Registry Expiry Date: 2026-07-23T12:00:00Z
+Expiry Date: 2026-06-23
+`)
+	if expiresAt == nil {
+		t.Fatalf("expected expiration date")
+	}
+	expected := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+	if !expiresAt.Equal(expected) {
+		t.Fatalf("expected earliest expiration %s, got %s", expected, *expiresAt)
+	}
+}

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -11,11 +11,12 @@ import (
 type Type string
 
 const (
-	TypeHTTP      Type = "http"
-	TypePing      Type = "ping"
-	TypeKeyword   Type = "keyword"
-	TypePort      Type = "port"
-	TypeHeartbeat Type = "heartbeat"
+	TypeHTTP             Type = "http"
+	TypePing             Type = "ping"
+	TypeKeyword          Type = "keyword"
+	TypePort             Type = "port"
+	TypeHeartbeat        Type = "heartbeat"
+	TypeDomainExpiration Type = "domain_expiration"
 )
 
 type Status string
@@ -164,6 +165,14 @@ type SSLResultPayload struct {
 	ExpiresAt    *time.Time `json:"expires_at"`
 	Issuer       *string    `json:"issuer"`
 	IssuedAt     *time.Time `json:"issued_at"`
+}
+
+type DomainResultPayload struct {
+	MonitoringID string     `json:"monitoring_id"`
+	IsValid      bool       `json:"is_valid"`
+	ExpiresAt    *time.Time `json:"expires_at"`
+	Registrar    *string    `json:"registrar"`
+	CheckedAt    time.Time  `json:"checked_at"`
 }
 
 func parseStringFlexible(value any, field string) (string, error) {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/m-breuer/webguard-instance-v2/internal/config"
 	"github.com/m-breuer/webguard-instance-v2/internal/core"
+	"github.com/m-breuer/webguard-instance-v2/internal/domainlookup"
 	"github.com/m-breuer/webguard-instance-v2/internal/monitor"
 	"github.com/m-breuer/webguard-instance-v2/internal/target"
 )
@@ -48,16 +49,26 @@ var sslMonitoringTypes = []monitor.Type{
 	monitor.TypePort,
 }
 
+var domainExpirationMonitoringTypes = []monitor.Type{
+	monitor.TypeDomainExpiration,
+}
+
 type CoreClient interface {
 	GetMonitorings(ctx context.Context, location string, types []monitor.Type) ([]monitor.Monitoring, error)
 	PostMonitoringResponse(ctx context.Context, payload monitor.MonitoringResponsePayload) error
 	PostSSLResult(ctx context.Context, payload monitor.SSLResultPayload) error
+	PostDomainResult(ctx context.Context, payload monitor.DomainResultPayload) error
+}
+
+type DomainLookup interface {
+	Lookup(ctx context.Context, target string) (domainlookup.Result, error)
 }
 
 type Runner struct {
-	client CoreClient
-	cfg    config.Config
-	logger *log.Logger
+	client       CoreClient
+	cfg          config.Config
+	logger       *log.Logger
+	domainLookup DomainLookup
 }
 
 func New(client CoreClient, cfg config.Config, logger *log.Logger) *Runner {
@@ -65,9 +76,10 @@ func New(client CoreClient, cfg config.Config, logger *log.Logger) *Runner {
 		logger = log.New(io.Discard, "", 0)
 	}
 	return &Runner{
-		client: client,
-		cfg:    cfg,
-		logger: logger,
+		client:       client,
+		cfg:          cfg,
+		logger:       logger,
+		domainLookup: domainlookup.New(10 * time.Second),
 	}
 }
 
@@ -227,31 +239,131 @@ func (r *Runner) runSSL(ctx context.Context) error {
 	return nil
 }
 
+func (r *Runner) runDomainExpiration(ctx context.Context) error {
+	r.logger.Println("Dispatching domain expiration monitoring jobs...")
+
+	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, domainExpirationMonitoringTypes)
+	if err != nil {
+		r.logFetchError(err)
+		return err
+	}
+
+	if len(monitorings) == 0 {
+		r.logger.Println("No active domain expiration monitoring found.")
+		return nil
+	}
+
+	dispatched := 0
+	skippedMaintenance := 0
+	skippedUnsupported := 0
+
+	jobs := make(chan monitor.Monitoring)
+	var workers sync.WaitGroup
+
+	workerCount := max(1, r.cfg.QueueDefaultWorkers)
+	for i := 0; i < workerCount; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for monitoring := range jobs {
+				status, domainPayload, hasDomainPayload := r.crawlDomainExpiration(ctx, monitoring)
+				r.logger.Printf(
+					"Domain expiration monitoring result computed (monitoring_id=%s status=%s)",
+					monitoring.ID,
+					status,
+				)
+				if err := r.client.PostMonitoringResponse(ctx, monitor.MonitoringResponsePayload{
+					MonitoringID:   monitoring.ID,
+					Status:         status,
+					ResponseTime:   nil,
+					HTTPStatusCode: nil,
+				}); err != nil {
+					r.logger.Printf("Failed to post domain expiration response result (monitoring_id=%s): %v", monitoring.ID, err)
+				}
+				if hasDomainPayload {
+					if err := r.client.PostDomainResult(ctx, domainPayload); err != nil {
+						r.logger.Printf("Failed to post domain expiration result (monitoring_id=%s): %v", monitoring.ID, err)
+					}
+				}
+			}
+		}()
+	}
+
+	for _, monitoring := range monitorings {
+		if monitoring.Type != monitor.TypeDomainExpiration {
+			skippedUnsupported++
+			r.logger.Printf(
+				"Skipping unsupported domain expiration monitoring (monitoring_id=%s type=%s)",
+				monitoring.ID,
+				monitoring.Type,
+			)
+			continue
+		}
+
+		if monitoring.MaintenanceActive {
+			skippedMaintenance++
+			if err := r.client.PostMonitoringResponse(ctx, monitor.MonitoringResponsePayload{
+				MonitoringID:   monitoring.ID,
+				Status:         monitor.StatusUnknown,
+				ResponseTime:   nil,
+				HTTPStatusCode: nil,
+			}); err != nil {
+				r.logger.Printf("Failed to post maintenance domain expiration response result (monitoring_id=%s): %v", monitoring.ID, err)
+			}
+			continue
+		}
+
+		dispatched++
+		jobs <- monitoring
+	}
+	close(jobs)
+	workers.Wait()
+
+	r.logger.Printf(
+		"Domain expiration monitoring dispatch done. total=%d dispatched=%d skipped_maintenance=%d skipped_unsupported=%d",
+		len(monitorings),
+		dispatched,
+		skippedMaintenance,
+		skippedUnsupported,
+	)
+
+	return nil
+}
+
 func (r *Runner) RunMonitoring(ctx context.Context) error {
 	r.logger.Println("Dispatching all monitoring jobs...")
 
-	var responseErr error
-	var sslErr error
+	type phaseResult struct {
+		name string
+		err  error
+	}
+
+	results := make(chan phaseResult, 3)
 	var phases sync.WaitGroup
-	phases.Add(2)
+	phases.Add(3)
 
 	go func() {
 		defer phases.Done()
-		responseErr = r.runResponse(ctx)
+		results <- phaseResult{name: "response", err: r.runResponse(ctx)}
 	}()
 
 	go func() {
 		defer phases.Done()
-		sslErr = r.runSSL(ctx)
+		results <- phaseResult{name: "SSL", err: r.runSSL(ctx)}
+	}()
+
+	go func() {
+		defer phases.Done()
+		results <- phaseResult{name: "domain expiration", err: r.runDomainExpiration(ctx)}
 	}()
 
 	phases.Wait()
+	close(results)
 
-	if responseErr != nil {
-		r.logger.Printf("response monitoring phase failed: %v", responseErr)
-	}
-	if sslErr != nil {
-		r.logger.Printf("SSL monitoring phase failed: %v", sslErr)
+	for result := range results {
+		if result.err != nil {
+			r.logger.Printf("%s monitoring phase failed: %v", result.name, result.err)
+		}
 	}
 
 	r.logger.Println("All monitoring jobs have been dispatched successfully.")
@@ -552,6 +664,45 @@ func (r *Runner) crawlMonitoringSSL(monitoring monitor.Monitoring) monitor.SSLRe
 	}
 
 	return payload
+}
+
+func (r *Runner) crawlDomainExpiration(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, monitor.DomainResultPayload, bool) {
+	lookup := r.domainLookup
+	if lookup == nil {
+		lookup = domainlookup.New(10 * time.Second)
+	}
+
+	result, err := lookup.Lookup(ctx, monitoring.Target)
+	if err != nil {
+		if domainlookup.IsTemporary(err) {
+			return monitor.StatusUnknown, monitor.DomainResultPayload{}, false
+		}
+		now := time.Now().UTC()
+		return monitor.StatusDown, monitor.DomainResultPayload{
+			MonitoringID: monitoring.ID,
+			IsValid:      false,
+			CheckedAt:    now,
+		}, true
+	}
+
+	checkedAt := result.CheckedAt
+	if checkedAt.IsZero() {
+		checkedAt = time.Now().UTC()
+	}
+
+	isValid := result.Registered && result.ExpiresAt != nil && result.ExpiresAt.After(checkedAt.Add(30*24*time.Hour))
+	status := monitor.StatusDown
+	if isValid {
+		status = monitor.StatusUp
+	}
+
+	return status, monitor.DomainResultPayload{
+		MonitoringID: monitoring.ID,
+		IsValid:      isValid,
+		ExpiresAt:    result.ExpiresAt,
+		Registrar:    result.Registrar,
+		CheckedAt:    checkedAt,
+	}, true
 }
 
 func normalizeHeaders(rawHeaders any) map[string]string {

--- a/internal/runner/runner_logic_test.go
+++ b/internal/runner/runner_logic_test.go
@@ -17,8 +17,22 @@ import (
 
 	"github.com/m-breuer/webguard-instance-v2/internal/config"
 	"github.com/m-breuer/webguard-instance-v2/internal/core"
+	"github.com/m-breuer/webguard-instance-v2/internal/domainlookup"
 	"github.com/m-breuer/webguard-instance-v2/internal/monitor"
 )
+
+type staticDomainLookup struct {
+	result domainlookup.Result
+	err    error
+}
+
+func (s staticDomainLookup) Lookup(_ context.Context, target string) (domainlookup.Result, error) {
+	result := s.result
+	if result.Domain == "" {
+		result.Domain = target
+	}
+	return result, s.err
+}
 
 func TestNormalizeHeaders(t *testing.T) {
 	t.Parallel()
@@ -499,6 +513,275 @@ func TestRunSSLPostsResults(t *testing.T) {
 	}
 	if postedSSL[0].MonitoringID != "3" {
 		t.Fatalf("unexpected monitoring id: %s", postedSSL[0].MonitoringID)
+	}
+}
+
+func TestRunDomainExpirationPostsUpResponseAndMetadata(t *testing.T) {
+	t.Parallel()
+
+	checkedAt := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	expiresAt := checkedAt.Add(60 * 24 * time.Hour)
+	registrar := "Example Registrar"
+	client := &fakeCoreClient{
+		domainMonitorings: []monitor.Monitoring{
+			{
+				ID:     "domain-1",
+				Type:   monitor.TypeDomainExpiration,
+				Target: "Example.COM.",
+			},
+		},
+	}
+
+	r := New(client, config.Config{
+		WebGuardLocation:    "de-1",
+		QueueDefaultWorkers: 1,
+	}, log.New(io.Discard, "", 0))
+	r.domainLookup = staticDomainLookup{
+		result: domainlookup.Result{
+			Domain:     "example.com",
+			Registered: true,
+			ExpiresAt:  &expiresAt,
+			Registrar:  &registrar,
+			CheckedAt:  checkedAt,
+		},
+	}
+
+	if err := r.runDomainExpiration(context.Background()); err != nil {
+		t.Fatalf("runDomainExpiration failed: %v", err)
+	}
+
+	postedResponses := client.snapshotPostedResponses()
+	if len(postedResponses) != 1 {
+		t.Fatalf("expected one response result, got %d", len(postedResponses))
+	}
+	if postedResponses[0].Status != monitor.StatusUp {
+		t.Fatalf("expected up response, got %s", postedResponses[0].Status)
+	}
+	if postedResponses[0].HTTPStatusCode != nil {
+		t.Fatalf("expected nil http status code")
+	}
+
+	postedDomains := client.snapshotPostedDomains()
+	if len(postedDomains) != 1 {
+		t.Fatalf("expected one domain result, got %d", len(postedDomains))
+	}
+	if !postedDomains[0].IsValid {
+		t.Fatalf("expected valid domain result")
+	}
+	if postedDomains[0].ExpiresAt == nil || !postedDomains[0].ExpiresAt.Equal(expiresAt) {
+		t.Fatalf("unexpected expiration date: %#v", postedDomains[0].ExpiresAt)
+	}
+	if postedDomains[0].Registrar == nil || *postedDomains[0].Registrar != registrar {
+		t.Fatalf("unexpected registrar: %#v", postedDomains[0].Registrar)
+	}
+	if !postedDomains[0].CheckedAt.Equal(checkedAt) {
+		t.Fatalf("unexpected checked_at: %s", postedDomains[0].CheckedAt)
+	}
+}
+
+func TestRunDomainExpirationExpiringWithinThirtyDaysIsDown(t *testing.T) {
+	t.Parallel()
+
+	checkedAt := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	expiresAt := checkedAt.Add(30 * 24 * time.Hour)
+	client := &fakeCoreClient{
+		domainMonitorings: []monitor.Monitoring{
+			{
+				ID:     "domain-2",
+				Type:   monitor.TypeDomainExpiration,
+				Target: "example.com",
+			},
+		},
+	}
+
+	r := New(client, config.Config{
+		WebGuardLocation:    "de-1",
+		QueueDefaultWorkers: 1,
+	}, log.New(io.Discard, "", 0))
+	r.domainLookup = staticDomainLookup{
+		result: domainlookup.Result{
+			Registered: true,
+			ExpiresAt:  &expiresAt,
+			CheckedAt:  checkedAt,
+		},
+	}
+
+	if err := r.runDomainExpiration(context.Background()); err != nil {
+		t.Fatalf("runDomainExpiration failed: %v", err)
+	}
+
+	postedResponses := client.snapshotPostedResponses()
+	if len(postedResponses) != 1 {
+		t.Fatalf("expected one response result, got %d", len(postedResponses))
+	}
+	if postedResponses[0].Status != monitor.StatusDown {
+		t.Fatalf("expected down response, got %s", postedResponses[0].Status)
+	}
+
+	postedDomains := client.snapshotPostedDomains()
+	if len(postedDomains) != 1 {
+		t.Fatalf("expected one domain result, got %d", len(postedDomains))
+	}
+	if postedDomains[0].IsValid {
+		t.Fatalf("expected invalid domain result")
+	}
+}
+
+func TestRunDomainExpirationTemporaryLookupFailurePostsUnknownOnly(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeCoreClient{
+		domainMonitorings: []monitor.Monitoring{
+			{
+				ID:     "domain-3",
+				Type:   monitor.TypeDomainExpiration,
+				Target: "example.com",
+			},
+		},
+	}
+
+	r := New(client, config.Config{
+		WebGuardLocation:    "de-1",
+		QueueDefaultWorkers: 1,
+	}, log.New(io.Discard, "", 0))
+	r.domainLookup = staticDomainLookup{
+		err: &domainlookup.TemporaryError{Err: errors.New("timeout")},
+	}
+
+	if err := r.runDomainExpiration(context.Background()); err != nil {
+		t.Fatalf("runDomainExpiration failed: %v", err)
+	}
+
+	postedResponses := client.snapshotPostedResponses()
+	if len(postedResponses) != 1 {
+		t.Fatalf("expected one response result, got %d", len(postedResponses))
+	}
+	if postedResponses[0].Status != monitor.StatusUnknown {
+		t.Fatalf("expected unknown response, got %s", postedResponses[0].Status)
+	}
+	if postedDomains := client.snapshotPostedDomains(); len(postedDomains) != 0 {
+		t.Fatalf("expected no domain result for temporary failure, got %d", len(postedDomains))
+	}
+}
+
+func TestRunDomainExpirationMaintenancePostsUnknownWithoutLookup(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeCoreClient{
+		domainMonitorings: []monitor.Monitoring{
+			{
+				ID:                "domain-maintenance",
+				Type:              monitor.TypeDomainExpiration,
+				Target:            "example.com",
+				MaintenanceActive: true,
+			},
+		},
+	}
+
+	r := New(client, config.Config{
+		WebGuardLocation:    "de-1",
+		QueueDefaultWorkers: 1,
+	}, log.New(io.Discard, "", 0))
+	r.domainLookup = staticDomainLookup{
+		err: errors.New("lookup should not run"),
+	}
+
+	if err := r.runDomainExpiration(context.Background()); err != nil {
+		t.Fatalf("runDomainExpiration failed: %v", err)
+	}
+
+	postedResponses := client.snapshotPostedResponses()
+	if len(postedResponses) != 1 {
+		t.Fatalf("expected one response result, got %d", len(postedResponses))
+	}
+	if postedResponses[0].Status != monitor.StatusUnknown {
+		t.Fatalf("expected unknown maintenance response, got %s", postedResponses[0].Status)
+	}
+	if postedDomains := client.snapshotPostedDomains(); len(postedDomains) != 0 {
+		t.Fatalf("expected no domain metadata during maintenance, got %d", len(postedDomains))
+	}
+}
+
+func TestRunDomainExpirationUsesCoreAPIEndpoints(t *testing.T) {
+	t.Parallel()
+
+	responseCh := make(chan monitor.MonitoringResponsePayload, 1)
+	domainCh := make(chan monitor.DomainResultPayload, 1)
+	checkedAt := time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC)
+	expiresAt := checkedAt.Add(90 * 24 * time.Hour)
+
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Header.Get("X-INSTANCE-CODE") != "de-1" {
+			http.Error(writer, "missing instance code", http.StatusBadRequest)
+			return
+		}
+		if request.Header.Get("X-API-KEY") != "secret-key" {
+			http.Error(writer, "missing api key", http.StatusBadRequest)
+			return
+		}
+
+		switch {
+		case request.Method == http.MethodGet && request.URL.Path == "/api/v1/internal/monitorings":
+			if request.URL.Query().Get("location") != "de-1" || request.URL.Query().Get("type") != "domain_expiration" {
+				http.Error(writer, "unexpected query", http.StatusBadRequest)
+				return
+			}
+			writer.Header().Set("Content-Type", "application/json")
+			_, _ = writer.Write([]byte(`[{"id":"domain-api","type":"domain_expiration","target":"example.com","maintenance_active":false}]`))
+		case request.Method == http.MethodPost && request.URL.Path == "/api/v1/internal/monitoring-responses":
+			var payload monitor.MonitoringResponsePayload
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				http.Error(writer, err.Error(), http.StatusBadRequest)
+				return
+			}
+			responseCh <- payload
+			writer.WriteHeader(http.StatusNoContent)
+		case request.Method == http.MethodPost && request.URL.Path == "/api/v1/internal/domain-results":
+			var payload monitor.DomainResultPayload
+			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+				http.Error(writer, err.Error(), http.StatusBadRequest)
+				return
+			}
+			domainCh <- payload
+			writer.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	r := New(core.NewClient(server.URL, "secret-key", "de-1"), config.Config{
+		WebGuardLocation:    "de-1",
+		QueueDefaultWorkers: 1,
+	}, log.New(io.Discard, "", 0))
+	r.domainLookup = staticDomainLookup{
+		result: domainlookup.Result{
+			Registered: true,
+			ExpiresAt:  &expiresAt,
+			CheckedAt:  checkedAt,
+		},
+	}
+
+	if err := r.runDomainExpiration(context.Background()); err != nil {
+		t.Fatalf("runDomainExpiration failed: %v", err)
+	}
+
+	select {
+	case payload := <-responseCh:
+		if payload.MonitoringID != "domain-api" || payload.Status != monitor.StatusUp {
+			t.Fatalf("unexpected response payload: %#v", payload)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("expected monitoring response post")
+	}
+
+	select {
+	case payload := <-domainCh:
+		if payload.MonitoringID != "domain-api" || !payload.IsValid {
+			t.Fatalf("unexpected domain payload: %#v", payload)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("expected domain result post")
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -26,11 +26,13 @@ type fakeCoreClient struct {
 
 	responseMonitorings []monitor.Monitoring
 	sslMonitorings      []monitor.Monitoring
+	domainMonitorings   []monitor.Monitoring
 
 	calls []getMonitoringsCall
 
 	postedResponses []monitor.MonitoringResponsePayload
 	postedSSL       []monitor.SSLResultPayload
+	postedDomains   []monitor.DomainResultPayload
 }
 
 func (f *fakeCoreClient) GetMonitorings(_ context.Context, location string, types []monitor.Type) ([]monitor.Monitoring, error) {
@@ -43,6 +45,9 @@ func (f *fakeCoreClient) GetMonitorings(_ context.Context, location string, type
 
 	if len(types) == len(responseMonitoringTypes) {
 		return append([]monitor.Monitoring(nil), f.responseMonitorings...), nil
+	}
+	if len(types) == len(domainExpirationMonitoringTypes) && types[0] == monitor.TypeDomainExpiration {
+		return append([]monitor.Monitoring(nil), f.domainMonitorings...), nil
 	}
 
 	return append([]monitor.Monitoring(nil), f.sslMonitorings...), nil
@@ -58,6 +63,13 @@ func (f *fakeCoreClient) PostMonitoringResponse(_ context.Context, payload monit
 func (f *fakeCoreClient) PostSSLResult(_ context.Context, payload monitor.SSLResultPayload) error {
 	f.mu.Lock()
 	f.postedSSL = append(f.postedSSL, payload)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeCoreClient) PostDomainResult(_ context.Context, payload monitor.DomainResultPayload) error {
+	f.mu.Lock()
+	f.postedDomains = append(f.postedDomains, payload)
 	f.mu.Unlock()
 	return nil
 }
@@ -78,6 +90,12 @@ func (f *fakeCoreClient) snapshotPostedSSL() []monitor.SSLResultPayload {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]monitor.SSLResultPayload(nil), f.postedSSL...)
+}
+
+func (f *fakeCoreClient) snapshotPostedDomains() []monitor.DomainResultPayload {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]monitor.DomainResultPayload(nil), f.postedDomains...)
 }
 
 func TestRunMonitoringMaintenancePostsUnknown(t *testing.T) {
@@ -105,12 +123,13 @@ func TestRunMonitoringMaintenancePostsUnknown(t *testing.T) {
 	}
 
 	calls := client.snapshotCalls()
-	if len(calls) != 2 {
-		t.Fatalf("expected 2 monitoring fetch calls, got %d", len(calls))
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 monitoring fetch calls, got %d", len(calls))
 	}
 
 	var foundResponseFetch bool
 	var foundSSLFetch bool
+	var foundDomainFetch bool
 	for _, call := range calls {
 		if call.location != "de-1" {
 			t.Fatalf("expected location de-1, got %q", call.location)
@@ -133,6 +152,11 @@ func TestRunMonitoringMaintenancePostsUnknown(t *testing.T) {
 			continue
 		}
 
+		if len(call.types) == 1 && call.types[0] == monitor.TypeDomainExpiration {
+			foundDomainFetch = true
+			continue
+		}
+
 		t.Fatalf("unexpected type filter: %#v", call.types)
 	}
 
@@ -141,6 +165,9 @@ func TestRunMonitoringMaintenancePostsUnknown(t *testing.T) {
 	}
 	if !foundSSLFetch {
 		t.Fatalf("ssl fetch call missing")
+	}
+	if !foundDomainFetch {
+		t.Fatalf("domain expiration fetch call missing")
 	}
 
 	postedResponses := client.snapshotPostedResponses()
@@ -180,8 +207,8 @@ func TestRunMonitoringRequestsNonPingTypesForSSL(t *testing.T) {
 	}
 
 	calls := client.snapshotCalls()
-	if len(calls) != 2 {
-		t.Fatalf("expected 2 monitoring fetch calls, got %d", len(calls))
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 monitoring fetch calls, got %d", len(calls))
 	}
 
 	var foundSSLFetch bool
@@ -201,7 +228,13 @@ func TestRunMonitoringRequestsNonPingTypesForSSL(t *testing.T) {
 			call.types[1] == monitor.TypeKeyword &&
 			call.types[2] == monitor.TypePort {
 			foundSSLFetch = true
+			continue
 		}
+		if len(call.types) == 1 && call.types[0] == monitor.TypeDomainExpiration {
+			continue
+		}
+
+		t.Fatalf("unexpected type filter: %#v", call.types)
 	}
 
 	if !foundSSLFetch {
@@ -327,6 +360,9 @@ func (p *parallelPhasesClient) GetMonitorings(_ context.Context, _ string, types
 	if len(types) == len(responseMonitoringTypes) {
 		phase = "response"
 	}
+	if len(types) == len(domainExpirationMonitoringTypes) && types[0] == monitor.TypeDomainExpiration {
+		phase = "domain"
+	}
 	p.started <- phase
 	<-p.release
 	return []monitor.Monitoring{}, nil
@@ -340,11 +376,15 @@ func (p *parallelPhasesClient) PostSSLResult(_ context.Context, _ monitor.SSLRes
 	return nil
 }
 
+func (p *parallelPhasesClient) PostDomainResult(_ context.Context, _ monitor.DomainResultPayload) error {
+	return nil
+}
+
 func TestRunMonitoringRunsPhasesInParallel(t *testing.T) {
 	t.Parallel()
 
 	client := &parallelPhasesClient{
-		started: make(chan string, 2),
+		started: make(chan string, 3),
 		release: make(chan struct{}),
 	}
 
@@ -362,12 +402,12 @@ func TestRunMonitoringRunsPhasesInParallel(t *testing.T) {
 
 	timeout := time.After(500 * time.Millisecond)
 	startedPhases := map[string]bool{}
-	for len(startedPhases) < 2 {
+	for len(startedPhases) < 3 {
 		select {
 		case phase := <-client.started:
 			startedPhases[phase] = true
 		case <-timeout:
-			t.Fatalf("expected both phases to start in parallel, got: %#v", startedPhases)
+			t.Fatalf("expected all phases to start in parallel, got: %#v", startedPhases)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds support for `domain_expiration` monitorings in the instance runner.

## Changes

- Fetches and dispatches `domain_expiration` monitorings in a new parallel phase.
- Posts normal monitoring responses with `http_status_code` and `response_time` set to `null`.
- Posts domain metadata to `/api/v1/internal/domain-results` when lookup results are available.
- Adds RDAP-first domain lookup with WHOIS fallback, target normalization, timeout handling, parent-domain fallback for subdomains, and common WHOIS expiration field parsing.
- Classifies expiring-within-30-days and missing/unavailable domain records as `down`, valid domains as `up`, and temporary lookup failures as `unknown`.
- Documents the new Core API endpoint in the README.

## Validation

- `go test ./...`
- `go test -race ./internal/runner`