### PR TITLE
Add DNS record monitoring support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,13 @@
 module github.com/m-breuer/webguard-instance-v2
 
 go 1.26
+
+require github.com/miekg/dns v1.1.72
+
+require (
+	golang.org/x/mod v0.31.0 // indirect
+	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/sync v0.19.0 // indirect
+	golang.org/x/sys v0.39.0 // indirect
+	golang.org/x/tools v0.40.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/miekg/dns v1.1.72 h1:vhmr+TF2A3tuoGNkLDFK9zi36F2LS+hKTRW0Uf8kbzI=
+github.com/miekg/dns v1.1.72/go.mod h1:+EuEPhdHOsfk6Wk5TT2CzssZdqkmFhf8r+aVyDEToIs=
+golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
+golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
+golang.org/x/net v0.48.0 h1:zyQRTTrjc33Lhh0fBgT/H3oZq9WuvRR5gPC70xpDiQU=
+golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
+golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/tools v0.40.0 h1:yLkxfA+Qnul4cs9QA3KnlFu0lVmd8JJfoq+E41uSutA=
+golang.org/x/tools v0.40.0/go.mod h1:Ik/tzLRlbscWpqqMRjyWYDisX8bG13FrdXp3o4Sr9lc=

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -15,6 +15,7 @@ const (
 	TypePing             Type = "ping"
 	TypeKeyword          Type = "keyword"
 	TypePort             Type = "port"
+	TypeDNSRecord        Type = "dns_record"
 	TypeHeartbeat        Type = "heartbeat"
 	TypeDomainExpiration Type = "domain_expiration"
 )
@@ -55,6 +56,9 @@ type Monitoring struct {
 	Keyword string `json:"keyword"`
 	Port    int    `json:"port"`
 
+	DNSRecordType     string   `json:"dns_record_type"`
+	DNSExpectedValues []string `json:"dns_expected_values"`
+
 	HeartbeatIntervalMinutes *int       `json:"heartbeat_interval_minutes"`
 	HeartbeatGraceMinutes    *int       `json:"heartbeat_grace_minutes"`
 	HeartbeatLastPingAt      *time.Time `json:"heartbeat_last_ping_at"`
@@ -81,6 +85,9 @@ func (m *Monitoring) UnmarshalJSON(data []byte) error {
 
 		Keyword string `json:"keyword"`
 		Port    any    `json:"port"`
+
+		DNSRecordType     string   `json:"dns_record_type"`
+		DNSExpectedValues []string `json:"dns_expected_values"`
 
 		HeartbeatIntervalMinutes any `json:"heartbeat_interval_minutes"`
 		HeartbeatGraceMinutes    any `json:"heartbeat_grace_minutes"`
@@ -141,6 +148,9 @@ func (m *Monitoring) UnmarshalJSON(data []byte) error {
 
 		Keyword: raw.Keyword,
 		Port:    port,
+
+		DNSRecordType:     raw.DNSRecordType,
+		DNSExpectedValues: raw.DNSExpectedValues,
 
 		HeartbeatIntervalMinutes: heartbeatIntervalMinutes,
 		HeartbeatGraceMinutes:    heartbeatGraceMinutes,

--- a/internal/monitor/types_test.go
+++ b/internal/monitor/types_test.go
@@ -101,3 +101,31 @@ func TestMonitoringUnmarshalHeartbeatMonitoring(t *testing.T) {
 		t.Fatalf("expected heartbeat_last_ping_at=%s, got %#v", expectedLastPingAt, monitoring.HeartbeatLastPingAt)
 	}
 }
+
+func TestMonitoringUnmarshalDNSRecordMonitoring(t *testing.T) {
+	t.Parallel()
+
+	var monitoring Monitoring
+	err := json.Unmarshal([]byte(`{
+		"id": "dns-42",
+		"type": "dns_record",
+		"target": "example.com",
+		"dns_record_type": "A",
+		"dns_expected_values": ["192.0.2.10", "192.0.2.11"],
+		"timeout": 5,
+		"maintenance_active": false
+	}`), &monitoring)
+	if err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if monitoring.Type != TypeDNSRecord {
+		t.Fatalf("expected type dns_record, got %s", monitoring.Type)
+	}
+	if monitoring.DNSRecordType != "A" {
+		t.Fatalf("expected dns_record_type A, got %q", monitoring.DNSRecordType)
+	}
+	if len(monitoring.DNSExpectedValues) != 2 || monitoring.DNSExpectedValues[0] != "192.0.2.10" || monitoring.DNSExpectedValues[1] != "192.0.2.11" {
+		t.Fatalf("unexpected dns_expected_values: %#v", monitoring.DNSExpectedValues)
+	}
+}

--- a/internal/runner/dns_record_checker.go
+++ b/internal/runner/dns_record_checker.go
@@ -1,0 +1,286 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/m-breuer/webguard-instance-v2/internal/monitor"
+	"github.com/miekg/dns"
+)
+
+const fixedDNSTimeoutSeconds = 5
+
+type DNSRecordResolver interface {
+	Resolve(ctx context.Context, target string, recordType string, timeout time.Duration) ([]string, error)
+}
+
+type DNSRecordChecker struct {
+	resolver DNSRecordResolver
+	logger   *log.Logger
+}
+
+func NewDNSRecordChecker(resolver DNSRecordResolver, logger *log.Logger) *DNSRecordChecker {
+	if resolver == nil {
+		resolver = systemDNSRecordResolver{}
+	}
+	return &DNSRecordChecker{
+		resolver: resolver,
+		logger:   logger,
+	}
+}
+
+func (c *DNSRecordChecker) Supports(monitoringType monitor.Type) bool {
+	return monitoringType == monitor.TypeDNSRecord
+}
+
+func (c *DNSRecordChecker) Check(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64) {
+	start := time.Now()
+	responseTime := func() *float64 {
+		elapsed := roundMilliseconds(time.Since(start))
+		return &elapsed
+	}
+
+	target := strings.TrimSpace(monitoring.Target)
+	recordType := strings.TrimSpace(monitoring.DNSRecordType)
+	if target == "" || recordType == "" || len(monitoring.DNSExpectedValues) == 0 {
+		c.logf("Invalid DNS monitoring configuration for %s %s: target/type/expected values are required", target, recordType)
+		return monitor.StatusDown, responseTime()
+	}
+
+	expected, err := normalizeDNSRecordValues(monitoring.DNSExpectedValues, recordType)
+	if err != nil {
+		c.logf("Invalid expected DNS values for %s %s: %v", target, recordType, err)
+		return monitor.StatusDown, responseTime()
+	}
+
+	timeout := fixedDNSTimeoutSeconds * time.Second
+	if monitoring.Timeout > 0 {
+		timeout = time.Duration(monitoring.Timeout) * time.Second
+	}
+
+	actualRaw, err := c.resolver.Resolve(ctx, target, recordType, timeout)
+	if err != nil {
+		c.logf("DNS lookup failed for %s %s: %v", target, recordType, err)
+		return monitor.StatusDown, responseTime()
+	}
+
+	actual, err := normalizeDNSRecordValues(actualRaw, recordType)
+	if err != nil {
+		c.logf("Invalid DNS response values for %s %s: %v", target, recordType, err)
+		return monitor.StatusDown, responseTime()
+	}
+
+	if slices.Equal(actual, expected) {
+		return monitor.StatusUp, responseTime()
+	}
+
+	c.logf("DNS mismatch for %s %s\nexpected: %q\nactual: %q", target, recordType, expected, actual)
+	return monitor.StatusDown, responseTime()
+}
+
+func (c *DNSRecordChecker) logf(format string, args ...any) {
+	if c.logger != nil {
+		c.logger.Printf(format, args...)
+	}
+}
+
+type systemDNSRecordResolver struct{}
+
+func (systemDNSRecordResolver) Resolve(ctx context.Context, target string, recordType string, timeout time.Duration) ([]string, error) {
+	qtype, ok := dns.StringToType[strings.ToUpper(strings.TrimSpace(recordType))]
+	if !ok {
+		return nil, fmt.Errorf("unsupported DNS record type: %s", recordType)
+	}
+
+	config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+	if err != nil || len(config.Servers) == 0 {
+		return nil, fmt.Errorf("DNS resolver configuration unavailable: %w", err)
+	}
+
+	server := net.JoinHostPort(config.Servers[0], config.Port)
+	message := new(dns.Msg)
+	message.SetQuestion(dns.Fqdn(strings.TrimSpace(target)), qtype)
+	message.RecursionDesired = true
+
+	client := &dns.Client{
+		Net:     "udp",
+		Timeout: timeout,
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	response, _, err := client.ExchangeContext(queryCtx, message, server)
+	if err != nil {
+		return nil, err
+	}
+	if response != nil && response.Truncated {
+		tcpClient := &dns.Client{Net: "tcp", Timeout: timeout}
+		response, _, err = tcpClient.ExchangeContext(queryCtx, message, server)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if response == nil {
+		return nil, errors.New("empty DNS response")
+	}
+	if response.Rcode != dns.RcodeSuccess {
+		return nil, fmt.Errorf("DNS response code %s", dns.RcodeToString[response.Rcode])
+	}
+
+	values := make([]string, 0, len(response.Answer))
+	for _, answer := range response.Answer {
+		if answer.Header().Rrtype != qtype {
+			continue
+		}
+		switch record := answer.(type) {
+		case *dns.A:
+			values = append(values, record.A.String())
+		case *dns.AAAA:
+			values = append(values, record.AAAA.String())
+		case *dns.CNAME:
+			values = append(values, record.Target)
+		case *dns.NS:
+			values = append(values, record.Ns)
+		case *dns.MX:
+			values = append(values, fmt.Sprintf("%d %s", record.Preference, record.Mx))
+		case *dns.TXT:
+			values = append(values, strings.Join(record.Txt, ""))
+		case *dns.SOA:
+			values = append(values, fmt.Sprintf(
+				"%s %s %d %d %d %d %d",
+				record.Ns,
+				record.Mbox,
+				record.Serial,
+				record.Refresh,
+				record.Retry,
+				record.Expire,
+				record.Minttl,
+			))
+		case *dns.CAA:
+			values = append(values, fmt.Sprintf("%d %s %s", record.Flag, record.Tag, record.Value))
+		}
+	}
+
+	if len(values) == 0 {
+		return nil, fmt.Errorf("DNS record %s not found", strings.ToUpper(recordType))
+	}
+
+	return values, nil
+}
+
+func normalizeDNSRecordValues(values []string, recordType string) ([]string, error) {
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+
+	for _, value := range values {
+		item, err := normalizeDNSRecordValue(value, recordType)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		normalized = append(normalized, item)
+	}
+
+	slices.Sort(normalized)
+	return normalized, nil
+}
+
+func normalizeDNSRecordValue(value string, recordType string) (string, error) {
+	recordType = strings.ToUpper(strings.TrimSpace(recordType))
+
+	switch recordType {
+	case "A":
+		ip := net.ParseIP(strings.TrimSpace(value))
+		if ip == nil || ip.To4() == nil {
+			return "", fmt.Errorf("invalid A record value: %q", value)
+		}
+		return ip.To4().String(), nil
+	case "AAAA":
+		ip := net.ParseIP(strings.TrimSpace(value))
+		if ip == nil || ip.To4() != nil || ip.To16() == nil {
+			return "", fmt.Errorf("invalid AAAA record value: %q", value)
+		}
+		return strings.ToLower(ip.String()), nil
+	case "CNAME", "NS":
+		host := normalizeDNSHostname(value)
+		if host == "" {
+			return "", fmt.Errorf("invalid %s record value: %q", recordType, value)
+		}
+		return host, nil
+	case "MX":
+		fields := strings.Fields(value)
+		if len(fields) != 2 {
+			return "", fmt.Errorf("invalid MX record value: %q", value)
+		}
+		priority, err := strconv.ParseUint(fields[0], 10, 16)
+		if err != nil {
+			return "", fmt.Errorf("invalid MX priority: %q", fields[0])
+		}
+		host := normalizeDNSHostname(fields[1])
+		if host == "" {
+			return "", fmt.Errorf("invalid MX host: %q", fields[1])
+		}
+		return fmt.Sprintf("%d %s", priority, host), nil
+	case "TXT":
+		return normalizeDNSTXT(value), nil
+	case "SOA":
+		fields := strings.Fields(value)
+		if len(fields) != 7 {
+			return "", fmt.Errorf("invalid SOA record value: %q", value)
+		}
+		ns := normalizeDNSHostname(fields[0])
+		mbox := normalizeDNSHostname(fields[1])
+		if ns == "" || mbox == "" {
+			return "", fmt.Errorf("invalid SOA host fields: %q", value)
+		}
+		numbers := make([]uint64, 5)
+		for i := 0; i < 5; i++ {
+			parsed, err := strconv.ParseUint(fields[i+2], 10, 32)
+			if err != nil {
+				return "", fmt.Errorf("invalid SOA numeric field: %q", fields[i+2])
+			}
+			numbers[i] = parsed
+		}
+		return fmt.Sprintf("%s %s %d %d %d %d %d", ns, mbox, numbers[0], numbers[1], numbers[2], numbers[3], numbers[4]), nil
+	case "CAA":
+		fields := strings.Fields(value)
+		if len(fields) < 3 {
+			return "", fmt.Errorf("invalid CAA record value: %q", value)
+		}
+		flags, err := strconv.ParseUint(fields[0], 10, 8)
+		if err != nil {
+			return "", fmt.Errorf("invalid CAA flags: %q", fields[0])
+		}
+		tag := strings.ToLower(strings.TrimSpace(fields[1]))
+		caaValue := normalizeDNSTXT(strings.Join(fields[2:], " "))
+		if tag == "" || caaValue == "" {
+			return "", fmt.Errorf("invalid CAA record value: %q", value)
+		}
+		return fmt.Sprintf("%d %s %s", flags, tag, caaValue), nil
+	default:
+		return "", fmt.Errorf("unsupported DNS record type: %s", recordType)
+	}
+}
+
+func normalizeDNSHostname(value string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(value)), ".")
+}
+
+func normalizeDNSTXT(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if unquoted, err := strconv.Unquote(trimmed); err == nil {
+		return unquoted
+	}
+	return strings.Trim(trimmed, `"`)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -41,6 +41,7 @@ var responseMonitoringTypes = []monitor.Type{
 	monitor.TypePing,
 	monitor.TypeKeyword,
 	monitor.TypePort,
+	monitor.TypeDNSRecord,
 }
 
 var sslMonitoringTypes = []monitor.Type{
@@ -69,6 +70,7 @@ type Runner struct {
 	cfg          config.Config
 	logger       *log.Logger
 	domainLookup DomainLookup
+	dnsChecker   *DNSRecordChecker
 }
 
 func New(client CoreClient, cfg config.Config, logger *log.Logger) *Runner {
@@ -80,6 +82,7 @@ func New(client CoreClient, cfg config.Config, logger *log.Logger) *Runner {
 		cfg:          cfg,
 		logger:       logger,
 		domainLookup: domainlookup.New(10 * time.Second),
+		dnsChecker:   NewDNSRecordChecker(nil, logger),
 	}
 }
 
@@ -391,6 +394,13 @@ func (r *Runner) crawlResponseMonitoring(ctx context.Context, monitoring monitor
 	case monitor.TypePort:
 		status, responseTime := handlePortMonitoring(monitoring)
 		return status, responseTime, nil
+	case monitor.TypeDNSRecord:
+		checker := r.dnsChecker
+		if checker == nil {
+			checker = NewDNSRecordChecker(nil, r.logger)
+		}
+		status, responseTime := checker.Check(ctx, monitoring)
+		return status, responseTime, nil
 	case monitor.TypeHeartbeat:
 		return monitor.StatusUnknown, nil, nil
 	default:
@@ -400,7 +410,7 @@ func (r *Runner) crawlResponseMonitoring(ctx context.Context, monitoring monitor
 
 func supportsResponseChecks(monitoringType monitor.Type) bool {
 	switch monitoringType {
-	case monitor.TypeHTTP, monitor.TypePing, monitor.TypeKeyword, monitor.TypePort:
+	case monitor.TypeHTTP, monitor.TypePing, monitor.TypeKeyword, monitor.TypePort, monitor.TypeDNSRecord:
 		return true
 	default:
 		return false

--- a/internal/runner/runner_logic_test.go
+++ b/internal/runner/runner_logic_test.go
@@ -34,6 +34,21 @@ func (s staticDomainLookup) Lookup(_ context.Context, target string) (domainlook
 	return result, s.err
 }
 
+type staticDNSRecordResolver struct {
+	values     []string
+	err        error
+	target     string
+	recordType string
+	timeout    time.Duration
+}
+
+func (s *staticDNSRecordResolver) Resolve(_ context.Context, target string, recordType string, timeout time.Duration) ([]string, error) {
+	s.target = target
+	s.recordType = recordType
+	s.timeout = timeout
+	return append([]string(nil), s.values...), s.err
+}
+
 func TestNormalizeHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -454,6 +469,215 @@ func TestCrawlResponseMonitoringPortReturnsNilHTTPStatusCode(t *testing.T) {
 	case <-done:
 	case <-time.After(100 * time.Millisecond):
 		t.Fatalf("port monitor did not connect to test listener")
+	}
+}
+
+func TestDNSRecordCheckerARecordMatchReportsUp(t *testing.T) {
+	t.Parallel()
+
+	resolver := &staticDNSRecordResolver{
+		values: []string{"192.0.2.10", "192.0.2.11"},
+	}
+	checker := NewDNSRecordChecker(resolver, log.New(io.Discard, "", 0))
+
+	status, responseTime := checker.Check(context.Background(), monitor.Monitoring{
+		Type:              monitor.TypeDNSRecord,
+		Target:            "example.com",
+		Timeout:           3,
+		DNSRecordType:     "A",
+		DNSExpectedValues: []string{"192.0.2.11", "192.0.2.10"},
+	})
+
+	if status != monitor.StatusUp {
+		t.Fatalf("expected up, got %s", status)
+	}
+	if responseTime == nil {
+		t.Fatalf("expected response time")
+	}
+	if resolver.target != "example.com" {
+		t.Fatalf("expected resolver target example.com, got %q", resolver.target)
+	}
+	if resolver.recordType != "A" {
+		t.Fatalf("expected resolver record type A, got %q", resolver.recordType)
+	}
+	if resolver.timeout != 3*time.Second {
+		t.Fatalf("expected resolver timeout 3s, got %s", resolver.timeout)
+	}
+}
+
+func TestDNSRecordCheckerARecordMismatchReportsDown(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDNSRecordChecker(&staticDNSRecordResolver{
+		values: []string{"192.0.2.20"},
+	}, log.New(io.Discard, "", 0))
+
+	status, responseTime := checker.Check(context.Background(), monitor.Monitoring{
+		Target:            "example.com",
+		DNSRecordType:     "A",
+		DNSExpectedValues: []string{"192.0.2.10"},
+	})
+
+	if status != monitor.StatusDown {
+		t.Fatalf("expected down, got %s", status)
+	}
+	if responseTime == nil {
+		t.Fatalf("expected response time")
+	}
+}
+
+func TestDNSRecordCheckerMissingRecordReportsDown(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDNSRecordChecker(&staticDNSRecordResolver{
+		err: errors.New("record not found"),
+	}, log.New(io.Discard, "", 0))
+
+	status, responseTime := checker.Check(context.Background(), monitor.Monitoring{
+		Target:            "example.com",
+		DNSRecordType:     "A",
+		DNSExpectedValues: []string{"192.0.2.10"},
+	})
+
+	if status != monitor.StatusDown {
+		t.Fatalf("expected down, got %s", status)
+	}
+	if responseTime == nil {
+		t.Fatalf("expected response time")
+	}
+}
+
+func TestDNSRecordCheckerExtraValueReportsDown(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDNSRecordChecker(&staticDNSRecordResolver{
+		values: []string{"192.0.2.10", "192.0.2.11"},
+	}, log.New(io.Discard, "", 0))
+
+	status, _ := checker.Check(context.Background(), monitor.Monitoring{
+		Target:            "example.com",
+		DNSRecordType:     "A",
+		DNSExpectedValues: []string{"192.0.2.10"},
+	})
+
+	if status != monitor.StatusDown {
+		t.Fatalf("expected down for unexpected extra value, got %s", status)
+	}
+}
+
+func TestDNSRecordCheckerUnsupportedRecordTypeReportsDown(t *testing.T) {
+	t.Parallel()
+
+	checker := NewDNSRecordChecker(&staticDNSRecordResolver{
+		values: []string{"value"},
+	}, log.New(io.Discard, "", 0))
+
+	status, responseTime := checker.Check(context.Background(), monitor.Monitoring{
+		Target:            "example.com",
+		DNSRecordType:     "HTTPS",
+		DNSExpectedValues: []string{"value"},
+	})
+
+	if status != monitor.StatusDown {
+		t.Fatalf("expected down for unsupported record type, got %s", status)
+	}
+	if responseTime == nil {
+		t.Fatalf("expected response time")
+	}
+}
+
+func TestNormalizeDNSRecordValues(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		recordType string
+		values     []string
+		expected   []string
+	}{
+		{
+			name:       "CNAME trailing dot",
+			recordType: "CNAME",
+			values:     []string{"Target.Example.COM."},
+			expected:   []string{"target.example.com"},
+		},
+		{
+			name:       "NS trailing dot",
+			recordType: "NS",
+			values:     []string{"NS1.Example.COM."},
+			expected:   []string{"ns1.example.com"},
+		},
+		{
+			name:       "MX priority and host",
+			recordType: "MX",
+			values:     []string{"10 Mail.EXAMPLE.com."},
+			expected:   []string{"10 mail.example.com"},
+		},
+		{
+			name:       "TXT quotes",
+			recordType: "TXT",
+			values:     []string{`"v=spf1 include:example.com ~all"`},
+			expected:   []string{"v=spf1 include:example.com ~all"},
+		},
+		{
+			name:       "SOA deterministic fields",
+			recordType: "SOA",
+			values:     []string{"NS1.Example.COM. Hostmaster.Example.COM. 2026051401 7200 3600 1209600 3600"},
+			expected:   []string{"ns1.example.com hostmaster.example.com 2026051401 7200 3600 1209600 3600"},
+		},
+		{
+			name:       "CAA fields",
+			recordType: "CAA",
+			values:     []string{`0 Issue "letsencrypt.org"`},
+			expected:   []string{"0 issue letsencrypt.org"},
+		},
+		{
+			name:       "order and duplicates",
+			recordType: "A",
+			values:     []string{"192.0.2.11", "192.0.2.10", "192.0.2.10"},
+			expected:   []string{"192.0.2.10", "192.0.2.11"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := normalizeDNSRecordValues(testCase.values, testCase.recordType)
+			if err != nil {
+				t.Fatalf("unexpected normalize error: %v", err)
+			}
+			if !reflect.DeepEqual(actual, testCase.expected) {
+				t.Fatalf("unexpected normalized values: got %#v want %#v", actual, testCase.expected)
+			}
+		})
+	}
+}
+
+func TestCrawlResponseMonitoringDNSRecordReturnsNilHTTPStatusCode(t *testing.T) {
+	t.Parallel()
+
+	r := New(nil, config.Config{}, log.New(io.Discard, "", 0))
+	r.dnsChecker = NewDNSRecordChecker(&staticDNSRecordResolver{
+		values: []string{"target.example.com."},
+	}, log.New(io.Discard, "", 0))
+
+	status, responseTime, httpStatusCode := r.crawlResponseMonitoring(context.Background(), monitor.Monitoring{
+		Type:              monitor.TypeDNSRecord,
+		Target:            "example.com",
+		DNSRecordType:     "CNAME",
+		DNSExpectedValues: []string{"target.example.com"},
+	})
+
+	if status != monitor.StatusUp {
+		t.Fatalf("expected up, got %s", status)
+	}
+	if responseTime == nil {
+		t.Fatalf("expected response time")
+	}
+	if httpStatusCode != nil {
+		t.Fatalf("expected nil http status code for dns_record monitoring")
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -135,11 +135,12 @@ func TestRunMonitoringMaintenancePostsUnknown(t *testing.T) {
 			t.Fatalf("expected location de-1, got %q", call.location)
 		}
 
-		if len(call.types) == 4 &&
+		if len(call.types) == 5 &&
 			call.types[0] == monitor.TypeHTTP &&
 			call.types[1] == monitor.TypePing &&
 			call.types[2] == monitor.TypeKeyword &&
-			call.types[3] == monitor.TypePort {
+			call.types[3] == monitor.TypePort &&
+			call.types[4] == monitor.TypeDNSRecord {
 			foundResponseFetch = true
 			continue
 		}
@@ -216,11 +217,12 @@ func TestRunMonitoringRequestsNonPingTypesForSSL(t *testing.T) {
 		if call.location != "us-1" {
 			t.Fatalf("expected location us-1, got %q", call.location)
 		}
-		if len(call.types) == 4 &&
+		if len(call.types) == 5 &&
 			call.types[0] == monitor.TypeHTTP &&
 			call.types[1] == monitor.TypePing &&
 			call.types[2] == monitor.TypeKeyword &&
-			call.types[3] == monitor.TypePort {
+			call.types[3] == monitor.TypePort &&
+			call.types[4] == monitor.TypeDNSRecord {
 			continue
 		}
 		if len(call.types) == 3 &&
@@ -347,6 +349,54 @@ func TestRunResponsePostsHTTPStatusCodeForHTTPAndKeywordMonitoring(t *testing.T)
 		if *payload.HTTPStatusCode != http.StatusCreated {
 			t.Fatalf("expected http_status_code=%d for %s, got %d", http.StatusCreated, monitoringID, *payload.HTTPStatusCode)
 		}
+	}
+}
+
+func TestRunResponsePostsDNSRecordResultWithNilHTTPStatusCode(t *testing.T) {
+	t.Parallel()
+
+	client := &fakeCoreClient{
+		responseMonitorings: []monitor.Monitoring{
+			{
+				ID:                "dns-monitoring",
+				Type:              monitor.TypeDNSRecord,
+				Target:            "example.com",
+				Timeout:           5,
+				DNSRecordType:     "A",
+				DNSExpectedValues: []string{"192.0.2.10"},
+			},
+		},
+	}
+
+	cfg := config.Config{
+		WebGuardLocation:    "de-1",
+		QueueDefaultWorkers: 1,
+	}
+	runner := New(client, cfg, log.New(io.Discard, "", 0))
+	runner.dnsChecker = NewDNSRecordChecker(&staticDNSRecordResolver{
+		values: []string{"192.0.2.10"},
+	}, log.New(io.Discard, "", 0))
+
+	if err := runner.runResponse(context.Background()); err != nil {
+		t.Fatalf("runResponse failed: %v", err)
+	}
+
+	postedResponses := client.snapshotPostedResponses()
+	if len(postedResponses) != 1 {
+		t.Fatalf("expected 1 posted response, got %d", len(postedResponses))
+	}
+	payload := postedResponses[0]
+	if payload.MonitoringID != "dns-monitoring" {
+		t.Fatalf("expected monitoring_id dns-monitoring, got %s", payload.MonitoringID)
+	}
+	if payload.Status != monitor.StatusUp {
+		t.Fatalf("expected up status, got %s", payload.Status)
+	}
+	if payload.ResponseTime == nil {
+		t.Fatalf("expected response_time")
+	}
+	if payload.HTTPStatusCode != nil {
+		t.Fatalf("expected nil http_status_code for dns record response")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds support for the new `dns_record` monitoring type in the webguard instance response-check flow.

- parses `dns_record_type` and `dns_expected_values` from Core monitoring payloads
- routes `dns_record` jobs through a dedicated DNS checker
- resolves and normalizes A, AAAA, CNAME, MX, TXT, NS, SOA, and CAA records
- compares expected and actual DNS values as sorted sets so response ordering does not matter
- posts monitoring responses with `http_status_code: null` and DNS response time in milliseconds
- logs mismatch details for operational debugging

## Validation

- `go test ./...`
- `go vet ./...`