### PR TITLE
feat: support multi-location monitoring assignments

### DIFF
--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -42,6 +42,9 @@ type Monitoring struct {
 	ID   string `json:"id"`
 	Type Type   `json:"type"`
 
+	PreferredLocation  string   `json:"preferred_location"`
+	PreferredLocations []string `json:"preferred_locations,omitempty"`
+
 	Target string `json:"target"`
 
 	Timeout int `json:"timeout"`
@@ -71,6 +74,9 @@ func (m *Monitoring) UnmarshalJSON(data []byte) error {
 		ID any `json:"id"`
 
 		Type Type `json:"type"`
+
+		PreferredLocation  string   `json:"preferred_location"`
+		PreferredLocations []string `json:"preferred_locations"`
 
 		Target string `json:"target"`
 
@@ -134,6 +140,9 @@ func (m *Monitoring) UnmarshalJSON(data []byte) error {
 	*m = Monitoring{
 		ID:   id,
 		Type: raw.Type,
+
+		PreferredLocation:  strings.TrimSpace(raw.PreferredLocation),
+		PreferredLocations: raw.PreferredLocations,
 
 		Target: raw.Target,
 

--- a/internal/monitor/types_test.go
+++ b/internal/monitor/types_test.go
@@ -56,6 +56,55 @@ func TestMonitoringUnmarshalWithStringID(t *testing.T) {
 	}
 }
 
+func TestMonitoringUnmarshalPreferredLocationFallback(t *testing.T) {
+	t.Parallel()
+
+	var monitoring Monitoring
+	err := json.Unmarshal([]byte(`{
+		"id": "42",
+		"type": "http",
+		"preferred_location": "de-1",
+		"target": "https://example.com",
+		"timeout": 10,
+		"maintenance_active": false
+	}`), &monitoring)
+	if err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if monitoring.PreferredLocation != "de-1" {
+		t.Fatalf("expected preferred_location de-1, got %q", monitoring.PreferredLocation)
+	}
+	if monitoring.PreferredLocations != nil {
+		t.Fatalf("expected preferred_locations to be nil for legacy payload, got %#v", monitoring.PreferredLocations)
+	}
+}
+
+func TestMonitoringUnmarshalPreferredLocations(t *testing.T) {
+	t.Parallel()
+
+	var monitoring Monitoring
+	err := json.Unmarshal([]byte(`{
+		"id": "42",
+		"type": "http",
+		"preferred_location": "de-1",
+		"preferred_locations": ["de-1", "us-1"],
+		"target": "https://example.com",
+		"timeout": 10,
+		"maintenance_active": false
+	}`), &monitoring)
+	if err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if monitoring.PreferredLocation != "de-1" {
+		t.Fatalf("expected preferred_location de-1, got %q", monitoring.PreferredLocation)
+	}
+	if len(monitoring.PreferredLocations) != 2 || monitoring.PreferredLocations[0] != "de-1" || monitoring.PreferredLocations[1] != "us-1" {
+		t.Fatalf("unexpected preferred_locations: %#v", monitoring.PreferredLocations)
+	}
+}
+
 func TestMonitoringUnmarshalWithInvalidID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What changed

- Added `preferred_location` and optional `preferred_locations` fields to the monitoring configuration model.
- Preserved legacy payload handling where only `preferred_location` is present.
- Added coverage for legacy and multi-location monitoring payloads.

## Why

WebGuard Core now includes the full location assignment list in monitoring payloads while keeping the legacy primary location field for older compatibility paths.

## Testing

- `go test ./...`

Docker-based verification was not rerun on the final branch because the local Docker daemon was unavailable.

## Risks and follow-up

No result submission endpoints were changed. No local location filtering exists in this instance service, so no filtering behavior was modified.