### PR TITLE
docs: add repository agent governance

### DIFF
--- a/.agent/skills/README.md
+++ b/.agent/skills/README.md
@@ -1,0 +1,18 @@
+# Shared Agent Skills
+
+Read the applicable `AGENTS.md` first, identify relevant skills, then read only those skills. `AGENTS.md` remains authoritative. If instructions conflict, report the conflict and apply the stricter or safer rule.
+
+| Skill | Purpose | Use when | File |
+| --- | --- | --- | --- |
+| Implement Feature | Add behavior to the Go worker | Adding monitoring, CLI, health, config, or integration behavior | `implement-feature/SKILL.md` |
+| Fix Bug | Correct broken behavior | Reproducing and fixing a defect | `fix-bug/SKILL.md` |
+| Write Tests | Add or improve tests | Coverage is missing or behavior needs regression protection | `write-tests/SKILL.md` |
+| Refactor Code | Improve structure without behavior changes | Simplifying or reorganizing existing code | `refactor-code/SKILL.md` |
+| Review Code | Review a diff or branch | Producing implementation, risk, and test findings | `review-code/SKILL.md` |
+| Update Dependencies | Change Go modules | Adding, removing, or upgrading dependencies | `update-dependencies/SKILL.md` |
+| API Change | Change HTTP/API contracts | Updating WebGuard Core client or health endpoint behavior | `api-change/SKILL.md` |
+| Monitoring Runner Change | Change check execution | Updating response, SSL, DNS, ping, port, keyword, or domain checks | `monitoring-runner-change/SKILL.md` |
+| Security Review | Assess security risk | Reviewing auth, secrets, input handling, external calls, or command execution | `security-review/SKILL.md` |
+| Documentation Change | Update docs only | Changing README, examples, or governance docs | `documentation-change/SKILL.md` |
+| CI/CD Change | Update automation | Changing GitHub Actions or release automation | `ci-cd-change/SKILL.md` |
+| Docker Change | Update container behavior | Changing Dockerfile, Compose, healthchecks, or runtime image behavior | `docker-change/SKILL.md` |

--- a/.agent/skills/api-change/SKILL.md
+++ b/.agent/skills/api-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: API Change
+
+## Purpose
+
+Change HTTP behavior or WebGuard Core integration contracts safely.
+
+## When to Use
+
+Use for changes to `internal/core`, `internal/monitor`, `internal/server`, endpoint paths, headers, JSON payloads, status handling, or health endpoints.
+
+## When Not to Use
+
+Do not use for runner-only logic that does not alter API contracts.
+
+## Required Context
+
+Read `AGENTS.md`, affected API code, existing client/server tests, and README API notes.
+
+## Relevant Project Areas
+
+`internal/core`, `internal/monitor`, `internal/server`, `cmd/webguard-instance`, README API contract section.
+
+## Procedure
+
+1. Identify whether the change affects Core API compatibility, worker health endpoints, or internal DTO parsing.
+2. Preserve authentication headers unless explicitly changing auth.
+3. Add tests for request method, path, query, headers, body, response parsing, and error handling where relevant.
+4. Keep timeouts and context propagation explicit.
+5. Update documentation when public behavior or environment requirements change.
+
+## Validation
+
+Run targeted client/server tests, `go test ./...`, and vet/build when implementation changed.
+
+## Expected Output
+
+Report contract changes, compatibility impact, changed files, validations, and migration risks.
+
+## Constraints
+
+Do not silently change JSON field names, endpoint paths, auth headers, or accepted methods.
+
+## Completion Criteria
+
+API behavior is tested, documented if externally visible, and compatible unless a breaking change was explicitly requested.

--- a/.agent/skills/ci-cd-change/SKILL.md
+++ b/.agent/skills/ci-cd-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: CI/CD Change
+
+## Purpose
+
+Modify GitHub Actions or release automation safely.
+
+## When to Use
+
+Use for `.github/workflows/`, `.github/scripts/`, release notes, changelog automation, permissions, or container publishing changes.
+
+## When Not to Use
+
+Do not use for application-only, Docker-only, or documentation-only changes unless CI behavior also changes.
+
+## Required Context
+
+Read `AGENTS.md`, affected workflow or script, and commands the workflow runs.
+
+## Relevant Project Areas
+
+`.github/workflows/ci.yml`, `.github/workflows/docker-image.yml`, `.github/scripts/update-changelog.sh`, `Dockerfile`, Go validation commands.
+
+## Procedure
+
+1. Preserve least-privilege workflow permissions.
+2. Keep CI steps aligned with local validation commands.
+3. Avoid changing release or publish behavior unless explicitly required.
+4. Validate shell syntax and command availability where possible.
+5. Document any intentional change in required checks.
+
+## Validation
+
+Run local equivalents of changed workflow commands when possible, plus Docker or Go checks affected by the workflow.
+
+## Expected Output
+
+Report workflow changes, validation, and any CI-only assumptions.
+
+## Constraints
+
+Do not add secrets, broaden permissions, or change publish targets without explicit approval.
+
+## Completion Criteria
+
+CI/CD behavior is minimal, reviewable, and locally validated where possible.

--- a/.agent/skills/docker-change/SKILL.md
+++ b/.agent/skills/docker-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Docker Change
+
+## Purpose
+
+Change container build or Compose runtime behavior safely.
+
+## When to Use
+
+Use for `Dockerfile`, `compose.yml`, `docker-compose.override.yml`, `.dockerignore`, healthchecks, ports, images, or container commands.
+
+## When Not to Use
+
+Do not use for Go code changes unless container behavior also changes.
+
+## Required Context
+
+Read `AGENTS.md`, Docker files, README Docker commands, and CI image-build steps.
+
+## Relevant Project Areas
+
+`Dockerfile`, `compose.yml`, `docker-compose.override.yml`, `.dockerignore`, `start-dev.sh`, `.github/workflows/ci.yml`, `.github/workflows/docker-image.yml`.
+
+## Procedure
+
+1. Preserve development, builder, and production target separation.
+2. Keep production image minimal and non-root unless explicitly changed.
+3. Keep healthchecks aligned with `/health`.
+4. Preserve Compose environment and port behavior unless the task requires changes.
+5. Avoid baking secrets or local `.env` values into images.
+
+## Validation
+
+Run compose validation and production image build; run Go tests if Docker changes affect build or runtime behavior.
+
+## Expected Output
+
+Report container behavior changed, validations, and operational risks.
+
+## Constraints
+
+Do not expose new ports, alter publish targets, change base images, or weaken healthchecks without a concrete reason.
+
+## Completion Criteria
+
+Docker behavior is validated, compatible with CI, and documented if user-facing.

--- a/.agent/skills/documentation-change/SKILL.md
+++ b/.agent/skills/documentation-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Documentation Change
+
+## Purpose
+
+Update repository documentation accurately and concisely.
+
+## When to Use
+
+Use for README, `.env.example` explanations, governance files, skill files, or operational documentation.
+
+## When Not to Use
+
+Do not use when code behavior changes require implementation skills first.
+
+## Required Context
+
+Read `AGENTS.md`, the documentation being changed, and source/config files needed to verify claims.
+
+## Relevant Project Areas
+
+`README.md`, `.env.example`, `AGENTS.md`, `.agent/skills/`, adapter files, workflow or Docker files referenced by docs.
+
+## Procedure
+
+1. Verify every technical statement against repository files.
+2. Document only existing commands and behavior unless the same task adds them.
+3. Keep documentation concise and task-focused.
+4. Avoid duplicating canonical rules across adapter files.
+5. Check for stale command references.
+
+## Validation
+
+Run `git diff --check`; run compose validation when docs reference Docker behavior.
+
+## Expected Output
+
+Report changed docs, validation, and any verified documentation gaps left unresolved.
+
+## Constraints
+
+Do not edit application code, dependencies, CI, or Docker files for documentation-only tasks unless explicitly requested.
+
+## Completion Criteria
+
+Documentation is accurate, concise, and aligned with current repository behavior.

--- a/.agent/skills/fix-bug/SKILL.md
+++ b/.agent/skills/fix-bug/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Fix Bug
+
+## Purpose
+
+Diagnose and correct a defect with minimal, testable changes.
+
+## When to Use
+
+Use when behavior is incorrect, tests fail, operational output is wrong, or a regression is reported.
+
+## When Not to Use
+
+Do not use for feature work without a defect, broad refactors, or dependency-only changes.
+
+## Required Context
+
+Read `AGENTS.md`, the failing behavior description, relevant tests, and the smallest source area that can explain the bug.
+
+## Relevant Project Areas
+
+All Go packages under `cmd/` and `internal/`, plus Docker or CI files only if they are part of the failure.
+
+## Procedure
+
+1. Reproduce or reason from an existing failing test.
+2. Identify the responsible boundary before editing.
+3. Add a regression test where feasible.
+4. Fix the root cause without unrelated cleanup.
+5. Check nearby error handling, timeouts, and context cancellation when the bug involves external work.
+
+## Validation
+
+Run the targeted test first, then `go test ./...`; add formatting, vet, build, Docker, or CI validation when relevant.
+
+## Expected Output
+
+Report root cause, files changed, tests added or updated, validations, and residual risk.
+
+## Constraints
+
+Do not weaken tests, suppress errors, hide failures in logs, or broaden retries/timeouts without a reason.
+
+## Completion Criteria
+
+The bug is fixed, regression coverage exists where feasible, and relevant validation passes or skipped checks are disclosed.

--- a/.agent/skills/implement-feature/SKILL.md
+++ b/.agent/skills/implement-feature/SKILL.md
@@ -1,0 +1,46 @@
+# Skill: Implement Feature
+
+## Purpose
+
+Add repository behavior while preserving the Go worker architecture and WebGuard Core contract.
+
+## When to Use
+
+Use for new monitoring behavior, configuration, CLI commands, health behavior, Core integration behavior, or operational behavior.
+
+## When Not to Use
+
+Do not use for pure documentation, dependency-only, CI-only, Docker-only, or review-only tasks.
+
+## Required Context
+
+Read `AGENTS.md`, the affected package, existing tests for that package, and any related skill such as `api-change` or `monitoring-runner-change`.
+
+## Relevant Project Areas
+
+`cmd/webguard-instance`, `internal/config`, `internal/core`, `internal/monitor`, `internal/runner`, `internal/scheduler`, `internal/server`, `internal/target`.
+
+## Procedure
+
+1. Identify the package that owns the behavior.
+2. Follow existing constructor, interface, DTO, and test patterns.
+3. Keep environment parsing in `internal/config`.
+4. Keep Core API details in `internal/core` and DTOs in `internal/monitor`.
+5. Add the smallest implementation that satisfies the task.
+6. Add or update behavior-focused tests.
+
+## Validation
+
+Run the formatting check, `go vet ./...`, `go test ./...`, and the relevant build command inside Docker when possible.
+
+## Expected Output
+
+Report changed behavior, changed files, validations, and any skipped checks or risks.
+
+## Constraints
+
+Do not change public contracts, endpoint paths, JSON field names, authentication headers, or scheduling behavior unless explicitly required.
+
+## Completion Criteria
+
+The feature works through observable behavior, relevant tests cover it, and required validation passes or skipped checks are disclosed.

--- a/.agent/skills/monitoring-runner-change/SKILL.md
+++ b/.agent/skills/monitoring-runner-change/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Monitoring Runner Change
+
+## Purpose
+
+Modify monitoring execution behavior safely.
+
+## When to Use
+
+Use for response, SSL, DNS record, ping, port, keyword, domain-expiration, concurrency, scheduling, or result-posting behavior.
+
+## When Not to Use
+
+Do not use for Core API client-only changes or documentation-only tasks.
+
+## Required Context
+
+Read `AGENTS.md`, `internal/runner`, related package tests, and affected DTOs in `internal/monitor`.
+
+## Relevant Project Areas
+
+`internal/runner`, `internal/domainlookup`, `internal/target`, `internal/monitor`, `internal/scheduler`.
+
+## Procedure
+
+1. Identify the monitoring type and result payload affected.
+2. Preserve maintenance handling, unsupported-type handling, worker limits, and context cancellation unless explicitly changed.
+3. Isolate external systems with fakes, injected functions, or test servers.
+4. Check timeout, retry, redirect, and command-execution behavior for regressions.
+5. Add tests for success, failure, and edge cases.
+
+## Validation
+
+Run runner-related tests, `go test ./...`, formatting, and vet.
+
+## Expected Output
+
+Report monitoring behavior changed, tests added or updated, validations, and operational risks.
+
+## Constraints
+
+Do not make live network behavior required for tests. Do not log credentials or sensitive target data unnecessarily.
+
+## Completion Criteria
+
+Runner behavior is deterministic under test, context-aware, and validated.

--- a/.agent/skills/refactor-code/SKILL.md
+++ b/.agent/skills/refactor-code/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Refactor Code
+
+## Purpose
+
+Improve code structure without changing observable behavior.
+
+## When to Use
+
+Use for scoped simplification, extracting duplication, improving testability, or aligning code with existing package responsibilities.
+
+## When Not to Use
+
+Do not use when behavior must change, tests are missing for risky behavior, or the task only needs documentation.
+
+## Required Context
+
+Read `AGENTS.md`, the affected package, tests covering the current behavior, and nearby usage sites.
+
+## Relevant Project Areas
+
+Go code under `cmd/` and `internal/`.
+
+## Procedure
+
+1. Define the behavior that must remain unchanged.
+2. Prefer small mechanical changes.
+3. Keep package boundaries intact.
+4. Add tests before refactoring if existing coverage is insufficient.
+5. Review the diff for accidental contract or log changes.
+
+## Validation
+
+Run formatting, targeted tests, and `go test ./...`; run `go vet ./...` for nontrivial refactors.
+
+## Expected Output
+
+Report the structural change, unchanged behavior, validations, and any coverage limitations.
+
+## Constraints
+
+Do not introduce speculative abstractions, rename public API casually, or mix refactoring with unrelated feature work.
+
+## Completion Criteria
+
+Behavior is preserved, the code is simpler or better isolated, and relevant validation passes.

--- a/.agent/skills/review-code/SKILL.md
+++ b/.agent/skills/review-code/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Review Code
+
+## Purpose
+
+Review a change for correctness, security, maintainability, and test coverage.
+
+## When to Use
+
+Use when asked to review a diff, branch, pull request, or local changes.
+
+## When Not to Use
+
+Do not use when the task is to implement changes directly unless review is also requested.
+
+## Required Context
+
+Read `AGENTS.md`, the diff, affected code, and relevant tests. Prefer targeted inspection over full repository scans.
+
+## Relevant Project Areas
+
+Any changed files, plus package owners and validation configuration that affect the change.
+
+## Procedure
+
+1. Identify behavior, security, and compatibility risks first.
+2. Check tests for meaningful coverage.
+3. Verify Docker, CI, or dependency changes against repository workflows.
+4. Prioritize actionable findings with file and line references.
+5. Avoid style-only findings unless they affect maintainability or configured checks.
+
+## Validation
+
+Run or inspect relevant commands only when useful for the review.
+
+## Expected Output
+
+Lead with findings ordered by severity, then open questions, then a brief summary if needed.
+
+## Constraints
+
+Do not include large code excerpts or duplicate findings. Do not invent requirements.
+
+## Completion Criteria
+
+Findings are specific, actionable, supported by repository context, and note missing validation or residual risk.

--- a/.agent/skills/security-review/SKILL.md
+++ b/.agent/skills/security-review/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Security Review
+
+## Purpose
+
+Assess or improve security-sensitive repository behavior.
+
+## When to Use
+
+Use for authentication, authorization assumptions, secrets, env handling, external HTTP calls, DNS/command execution, logging, Docker hardening, or CI permissions.
+
+## When Not to Use
+
+Do not use for general code review unless security risk is in scope.
+
+## Required Context
+
+Read `AGENTS.md`, the affected code or config, related tests, and relevant Docker or workflow files.
+
+## Relevant Project Areas
+
+`internal/core`, `internal/config`, `internal/runner`, `internal/server`, Docker files, GitHub Actions, `.env.example`.
+
+## Procedure
+
+1. Identify trust boundaries and sensitive values.
+2. Check for secret exposure, unsafe logging, missing timeouts, unsafe command execution, and unvalidated external input.
+3. Verify auth headers and Core API configuration are preserved.
+4. Prefer restrictive defaults and explicit errors.
+5. Add tests for security-relevant behavior where feasible.
+
+## Validation
+
+Run relevant tests and build checks for changed code; inspect Docker and workflow permissions for config-only changes.
+
+## Expected Output
+
+Report risks, changes or findings, validations, and residual assumptions.
+
+## Constraints
+
+Do not publish secrets, weaken security controls, add telemetry, or upload repository content externally without approval.
+
+## Completion Criteria
+
+Security-sensitive behavior is explicit, tested where feasible, and does not weaken existing protections.

--- a/.agent/skills/update-dependencies/SKILL.md
+++ b/.agent/skills/update-dependencies/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Update Dependencies
+
+## Purpose
+
+Add, remove, or update Go module dependencies safely.
+
+## When to Use
+
+Use for changes to `go.mod` or `go.sum`.
+
+## When Not to Use
+
+Do not use for ordinary code changes that do not affect dependencies.
+
+## Required Context
+
+Read `AGENTS.md`, `go.mod`, relevant imports, and tests for code using the dependency.
+
+## Relevant Project Areas
+
+`go.mod`, `go.sum`, Go packages importing the dependency, Docker build behavior.
+
+## Procedure
+
+1. Confirm the dependency is necessary and not covered by the standard library or existing packages.
+2. Check maintenance, license, security posture, size, and transitive dependencies.
+3. Make only the requested dependency changes.
+4. Keep lockfile changes tied to dependency changes.
+5. Update code and tests that rely on the dependency.
+
+## Validation
+
+Run dependency download, `go test ./...`, relevant build, and production image build when dependency changes can affect containers.
+
+## Expected Output
+
+Report dependency changes, reason, validations, and any security or maintenance risk.
+
+## Constraints
+
+No unrelated upgrades, duplicate libraries, unrequested major-version changes, or lockfile churn.
+
+## Completion Criteria
+
+Dependencies are justified, module files are consistent, and validation passes.

--- a/.agent/skills/write-tests/SKILL.md
+++ b/.agent/skills/write-tests/SKILL.md
@@ -1,0 +1,45 @@
+# Skill: Write Tests
+
+## Purpose
+
+Add or improve deterministic Go tests for repository behavior.
+
+## When to Use
+
+Use when adding coverage, protecting a bug fix, updating behavior, or reviewing insufficient tests.
+
+## When Not to Use
+
+Do not use for changes where no behavior changes and existing validation is enough.
+
+## Required Context
+
+Read `AGENTS.md`, the package under test, existing `*_test.go` files in that package, and related DTO or interface definitions.
+
+## Relevant Project Areas
+
+Go tests under `cmd/` and `internal/`.
+
+## Procedure
+
+1. Match existing table-test and fake-client patterns.
+2. Test observable package behavior.
+3. Use `httptest`, fake interfaces, or injected executors instead of real external systems.
+4. Cover errors, edge cases, and compatibility parsing when relevant.
+5. Keep tests deterministic and isolated.
+
+## Validation
+
+Run the targeted package test and `go test ./...`; run formatting check when Go files changed.
+
+## Expected Output
+
+Report covered behavior, changed test files, validation results, and remaining coverage gaps if material.
+
+## Constraints
+
+Do not update snapshots blindly, skip tests without reason, depend on live WebGuard Core, or require external network access unless explicitly approved.
+
+## Completion Criteria
+
+Tests fail for the wrong behavior where feasible, pass after the change, and remain deterministic.

--- a/.cursor/rules/agent-governance.mdc
+++ b/.cursor/rules/agent-governance.mdc
@@ -1,0 +1,8 @@
+---
+description: Repository governance for all coding agents
+alwaysApply: true
+---
+
+Read and follow `AGENTS.md` before implementing changes. If a local `AGENTS.md` applies, follow it for directory-specific details without weakening root requirements.
+
+Use `.agent/skills/README.md` to identify relevant shared skills, then read only those skill files. Keep changes scoped, prefer Docker-based validation, and keep outputs concise.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# GitHub Copilot Repository Instructions
+
+This repository is governed by the root `AGENTS.md`.
+
+Follow `AGENTS.md`, any applicable local `AGENTS.md`, and the relevant shared skills listed in `.agent/skills/README.md`. Do not duplicate or contradict the canonical rules. Keep changes minimal, reviewable, secure, and validated with the repository's Docker-first workflow where possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,89 @@
-# Repository Instructions
+# Repository Agent Instructions
+
+These instructions apply to every human or AI coding agent working in this repository, regardless of the tool, model, IDE, extension, CLI, automation platform, or execution environment.
+
+## Scope and Applicability
+
+- This root `AGENTS.md` is the canonical source of project-wide instructions.
+- Local `AGENTS.md` files MAY add directory-specific rules. The nearest applicable `AGENTS.md` takes precedence for local implementation details.
+- Local rules MUST NOT weaken security, privacy, compliance, validation, or review requirements from this file.
+- Agent-specific adapter files MUST be thin references to this file, local `AGENTS.md` files, and `.agent/skills/`. They MUST NOT duplicate or contradict the canonical rules.
+- Shared skills in `.agent/skills/` supplement this file for recurring task types and MUST remain tool-independent.
+
+## Adapter Coverage
+
+- Committed adapters exist for Claude Code, Cursor, and GitHub Copilot.
+- OpenAI Codex, OpenCode, Windsurf, Cline, Roo Code, Aider, GitHub Copilot Coding Agent, and comparable IDE-, CLI-, or automation-based agents are governed directly by this file and `.agent/skills/` unless a supported adapter is added later.
+- Do not add adapter files for tools whose repository format is not clearly supported or already present.
+
+## Instruction Priority
+
+Apply instructions in this order:
+
+1. Explicit task requirements and acceptance criteria.
+2. Security, privacy, legal, and compliance requirements.
+3. Nearest applicable local `AGENTS.md`.
+4. Root `AGENTS.md`.
+5. Existing architecture and established repository patterns.
+6. Repository configuration.
+7. Tests and technical documentation.
+8. Official Go, Docker, and GitHub Actions documentation.
+9. Established community standards.
+10. Explicitly documented assumptions.
+
+Agents MUST NOT invent business requirements.
+
+## Token Efficiency
+
+- Read only files relevant to the current task.
+- Prefer precise searches over broad file reads.
+- Do not scan the full repository when targeted inspection is sufficient.
+- Avoid repeatedly reading unchanged files.
+- Do not restate the complete task before starting.
+- Do not repeat rules already defined in this file.
+- Do not include long implementation plans unless task complexity requires them.
+- Keep plans concise and focused on execution-critical steps.
+- Do not narrate routine tool usage.
+- Report only findings that affect implementation, validation, risk, or review.
+- Prefer diffs and targeted edits over rewriting complete files.
+- Avoid creating abstractions, documentation, comments, tests, or files that are not required.
+- Do not produce large code excerpts in final output when file references are sufficient.
+- Do not duplicate the same information across summaries, findings, and completion reports.
+- Use concise tables or short lists where they reduce repetition.
+- Preserve correctness, security, and completeness; token efficiency MUST NOT justify skipping required analysis or validation.
+
+Final output SHOULD normally contain only what changed, which files changed, which validations ran, and unresolved issues, assumptions, or risks.
+
+## Project Overview
+
+- `webguard-instance` is a Go worker node for WebGuard Core.
+- The service fetches monitoring jobs from WebGuard Core, executes response, SSL, DNS record, ping, port, keyword, and domain-expiration checks, and posts results back to the Core internal API.
+- Main entry point: `cmd/webguard-instance/main.go`.
+- Primary packages:
+  - `internal/config`: environment-derived runtime configuration.
+  - `internal/core`: WebGuard Core HTTP API client.
+  - `internal/monitor`: monitoring DTOs, payloads, enum-like types, and flexible JSON parsing.
+  - `internal/runner`: monitoring orchestration and check execution.
+  - `internal/domainlookup`: domain lookup integration.
+  - `internal/scheduler`: five-minute scheduling.
+  - `internal/server`: `/` and `/health` health endpoints.
+  - `internal/target`: target normalization helpers.
+- Runtime model: Docker-first Go service built from `Dockerfile`, composed by `compose.yml` and `docker-compose.override.yml`.
+- CI runs Go formatting, vet, tests, binary build, and a production Docker image build in `.github/workflows/ci.yml`.
+- Release image publishing and tag changelog generation are defined in `.github/workflows/docker-image.yml`.
+
+## Source of Truth
+
+Use this technical priority:
+
+1. Existing implementation and established patterns.
+2. Project configuration.
+3. Tests.
+4. Repository documentation.
+5. Official Go, Docker, and GitHub Actions documentation.
+6. Established standards.
+
+Agents MUST NOT replace existing conventions with personal preferences without a concrete technical reason.
 
 ## Environment
 
@@ -23,7 +108,61 @@ docker compose run --rm webguard-instance go test ./...
 
 The production image has `webguard-instance` as entrypoint. If `docker compose run ... go test` is interpreted as an application command, rebuild the development target first with `docker compose build webguard-instance`.
 
-## Test Concept
+## Language and Framework Standards
+
+- Go code MUST be idiomatic, `gofmt`-formatted, and compatible with the Go version declared in `go.mod`.
+- Keep package APIs small. Export names only when required by another package or tests.
+- Public types, constructors, and behavior that are part of package contracts SHOULD be explicit and stable.
+- Use `context.Context` for cancellation across HTTP calls, scheduled work, and runner operations.
+- Return errors instead of panicking in application code.
+- Wrap or preserve errors where useful for callers and tests.
+- Keep HTTP clients configured with explicit timeouts.
+- Use standard-library facilities before adding dependencies.
+- Keep JSON field names compatible with the WebGuard Core API contract.
+- Preserve the existing CLI commands: `serve` and `monitoring`.
+
+## Architecture Rules
+
+- `cmd/webguard-instance` MUST remain the composition boundary for configuration, logging, service construction, and command dispatch.
+- Business logic for monitoring execution belongs in `internal/runner` or a focused package under `internal/`.
+- WebGuard Core API request construction and response handling belong in `internal/core`.
+- API DTOs and monitoring payload types belong in `internal/monitor`.
+- Health endpoint behavior belongs in `internal/server`.
+- Scheduling behavior belongs in `internal/scheduler`.
+- Environment parsing belongs in `internal/config`; do not read environment variables throughout unrelated packages.
+- External integrations MUST be behind interfaces when tests or alternate implementations need isolation.
+- Concurrent code MUST honor context cancellation and avoid goroutine leaks.
+- New abstractions require a concrete benefit such as testability, isolation of an external dependency, or reduced meaningful duplication.
+
+## Code Quality
+
+- Run configured formatting, vetting, tests, and builds relevant to the change.
+- Keep functions focused and names domain-specific.
+- Avoid dead code, commented-out code, unused imports, unused variables, and speculative abstractions.
+- Use constants for repeated or meaningful values.
+- Comments SHOULD explain why, not restate what the code does.
+- Do not introduce broad ignore rules, blanket lint suppressions, unsafe casts, or type bypasses.
+- Do not weaken existing quality checks, tests, timeouts, authentication headers, or error handling.
+- Identify breaking changes explicitly.
+
+## Naming Conventions
+
+- Go packages use short lowercase names without underscores.
+- Go files use lowercase names; tests use `*_test.go`.
+- Tests SHOULD name the behavior under test, following existing `Test...` patterns.
+- Interfaces SHOULD describe required behavior and stay close to their consumers.
+- Environment variables are uppercase snake case and must be documented in `.env.example` and relevant docs when added.
+- WebGuard Core JSON fields and endpoint paths MUST remain compatible with the existing API contract unless the task explicitly changes that contract.
+
+## Testing Rules
+
+- The repository uses Go tests colocated with packages in `cmd/` and `internal/`.
+- Add or update tests for new or changed business logic.
+- Add regression tests for bug fixes where feasible.
+- Test observable behavior, package contracts, and edge cases rather than implementation details.
+- Use standard Go test isolation; avoid real network calls when an HTTP test server, fake client, or injected interface can cover behavior.
+- Do not remove or weaken tests merely to make a change pass.
+- Do not ignore failing tests. If a relevant check cannot run, state why.
 
 Every test change or test review must follow this process:
 
@@ -76,14 +215,130 @@ When adding or optimizing tests, prioritize these areas first:
 - `cmd/webguard-instance`: behavior when `RunMonitoring` returns an error.
 - `internal/runner`: retry behavior without real sleeps, ping execution without global mutation, response/SSL/domain phase dispatch with exact type assertions.
 
-## Handoff Expectations
+## Validation Commands
 
-When finishing test-related work, report:
+Prefer running commands inside the project Docker environment when technically possible. Use project-defined Docker Compose files before host-local tools.
 
-- which Docker commands were run;
-- whether the full suite passed;
-- coverage command results when relevant;
-- whether repeated/flakiness checks were run;
-- whether `-race` ran or why it could not run.
+| Purpose | Command |
+| --- | --- |
+| Compose validation | `docker compose -f compose.yml -f docker-compose.override.yml config` |
+| Development image build | `docker compose build webguard-instance` |
+| Dependency download | `docker compose -f compose.yml -f docker-compose.override.yml run --rm webguard-instance go mod download` |
+| Formatting check | `docker compose -f compose.yml -f docker-compose.override.yml run --rm webguard-instance sh -lc 'test -z "$(gofmt -l .)"'` |
+| Vet | `docker compose -f compose.yml -f docker-compose.override.yml run --rm webguard-instance go vet ./...` |
+| Tests | `docker compose -f compose.yml -f docker-compose.override.yml run --rm webguard-instance go test ./...` |
+| Coverage | `docker compose -f compose.yml -f docker-compose.override.yml run --rm webguard-instance go test -cover ./...` |
+| Timing-sensitive repeats | `docker compose -f compose.yml -f docker-compose.override.yml run --rm webguard-instance go test -count=10 ./internal/runner ./internal/server ./internal/scheduler` |
+| Race detector | `docker compose -f compose.yml -f docker-compose.override.yml run --rm -e CGO_ENABLED=1 webguard-instance go test -race ./...` |
+| Binary build | `docker compose -f compose.yml -f docker-compose.override.yml run --rm webguard-instance go build ./cmd/webguard-instance` |
+| Production image build | `docker build --target production -t webguard-instance:test .` |
+| Local development | `./start-dev.sh` |
+| One-off monitoring | `docker compose -f compose.yml run --rm webguard-instance monitoring` |
 
-Do not mention any AI assistant, automation tool, or code generation tool in code comments, commit messages, pull request titles, pull request descriptions, or repository documentation unless explicitly required.
+Use this matrix to choose checks:
+
+| Change type | Required validation |
+| --- | --- |
+| Documentation or governance | `docker compose ... config`, relevant diff review |
+| Go logic | formatting check, `go vet ./...`, `go test ./...`, relevant build |
+| WebGuard Core API contract | tests covering request/response behavior and relevant runner/client tests |
+| Monitoring runner behavior | runner tests and `go test ./...`; repeat timing-sensitive packages when touched |
+| Docker | compose validation and production image build |
+| CI/CD | workflow review plus local commands matching changed workflow steps where possible |
+| Dependencies | dependency download, lockfile review, tests, build |
+
+If a command cannot be executed, disclose the reason.
+
+When finishing test-related work, report which Docker commands were run, whether the full suite passed, coverage results when relevant, whether repeated/flakiness checks were run, and whether `-race` ran or why it could not run.
+
+## Dependency Management
+
+- Go modules are managed by `go.mod` and `go.sum`.
+- Do not change `go.sum` without a corresponding dependency change.
+- Prefer the standard library before adding dependencies.
+- New dependencies require a concrete need and review for maintenance, security, license, size, transitive dependencies, and runtime impact.
+- Do not add duplicate libraries for functionality already present.
+- Do not perform unrelated upgrades or unrequested major-version updates.
+
+## Security, Privacy, and Compliance
+
+- Do not commit secrets, credentials, tokens, or production personal data.
+- `.env` is local configuration; `.env.example` documents expected variables.
+- Use `WEBGUARD_CORE_API_KEY`, `WEBGUARD_CORE_API_URL`, and `WEBGUARD_LOCATION` through existing configuration mechanisms.
+- Preserve `X-API-KEY` and `X-INSTANCE-CODE` authentication headers for WebGuard Core calls.
+- Validate and normalize input at trust boundaries, including environment, HTTP responses, CLI arguments, and Core API payloads.
+- Use context-aware, timeout-bounded HTTP and command execution.
+- Avoid logging secrets, auth headers, credentials, request bodies containing sensitive data, or internal error details not needed for operations.
+- Use injection-safe shell and command patterns; do not concatenate untrusted input into shell commands.
+- Do not disable security controls or add telemetry, external services, or outbound integrations without explicit approval.
+- Do not upload repository content to external systems without authorization.
+
+## API and Integration Rules
+
+- WebGuard Core internal endpoints currently used by this worker are:
+  - `GET /api/v1/internal/monitorings`
+  - `POST /api/v1/internal/monitoring-responses`
+  - `POST /api/v1/internal/ssl-results`
+  - `POST /api/v1/internal/domain-results`
+- Health endpoints are `GET /` and `GET /health`; other methods return `405`.
+- Preserve request headers, JSON field names, status handling, and timeout behavior unless the task explicitly changes the contract.
+- Use test servers or fakes for Core API behavior in tests.
+- External DNS, ping, TLS, and domain lookup behavior MUST be isolated in tests where feasible.
+
+## Docker and Operations Rules
+
+- Docker is the preferred execution environment.
+- `Dockerfile` has `development`, `builder`, and `production` targets; preserve that separation.
+- `compose.yml` describes production-style service settings, healthcheck, ports, env file, restart policy, and image name.
+- `docker-compose.override.yml` switches the service to the development target and mounts the repository.
+- Do not commit local `.env` values.
+- Keep healthcheck behavior aligned with the service health endpoints.
+
+## Documentation Rules
+
+- Update documentation when commands, environment variables, operational behavior, public API contracts, or setup steps change.
+- Do not document commands that do not exist or have not been verified in the repository.
+- Do not make unverified claims about external systems.
+- Do not manually edit generated release notes or generated changelog content unless the workflow explicitly requires it.
+- Do not mention any AI assistant, automation tool, or code generation tool in code comments, commit messages, pull request titles, pull request descriptions, or repository documentation unless explicitly required.
+
+## Git and Change Scope
+
+- Limit changes to the task.
+- Do not perform unrelated refactors or format untouched files.
+- Do not manually edit generated files unless required by the task.
+- Do not overwrite local changes from another author.
+- Do not run destructive Git commands without explicit instruction.
+- Do not create commits, pushes, tags, releases, pull requests, CI/CD changes, infrastructure changes, or security-policy changes without explicit instruction and task relevance.
+- Keep changes small and reviewable.
+- Branch names MUST describe the work and MUST NOT include coding-agent or automation-tool branding.
+
+## Agent Workflow
+
+1. Read the task and acceptance criteria.
+2. Read this file and the nearest local `AGENTS.md`, if any.
+3. Identify and read only relevant skills from `.agent/skills/`.
+4. Inspect only relevant files and existing patterns.
+5. Evaluate architecture, dependencies, and risks.
+6. Plan the smallest viable change.
+7. Implement the change.
+8. Add or update tests where behavior changes.
+9. Run relevant validation commands.
+10. Review the diff for unintended changes.
+11. Report changes, validation, assumptions, and remaining risks concisely.
+
+Agents MUST NOT begin implementation before checking relevant rules and skills.
+
+## Definition of Done
+
+A task is complete only when:
+
+- Acceptance criteria are met.
+- Architecture rules are followed.
+- Relevant tests exist for behavior changes.
+- Required validation succeeds or skipped checks are disclosed.
+- No known unnecessary warnings remain.
+- Security and privacy requirements are met.
+- Documentation is updated where required.
+- No unintended files changed.
+- Assumptions and remaining risks are stated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# Claude Code Adapter
+
+This repository is governed by `AGENTS.md`.
+
+Before making changes, read:
+
+1. `AGENTS.md`
+2. The nearest local `AGENTS.md`, if one applies
+3. `.agent/skills/README.md`
+4. Only the task-relevant skill files under `.agent/skills/`
+
+Follow the canonical rules, keep changes within scope, prefer Docker-based validation, and keep execution notes and final output concise.


### PR DESCRIPTION
## What changed

- Expanded the root `AGENTS.md` into the canonical repository governance source while preserving the existing Docker and test guidance from `main`.
- Added shared, tool-independent skills under `.agent/skills/` for common repository workflows.
- Added thin adapters for Claude Code, Cursor, and GitHub Copilot that reference the canonical rules instead of duplicating them.

## Why

The repository now has one maintainable instruction system that applies consistently across coding tools while reflecting the actual Go, Docker, Compose, and GitHub Actions setup.

## Testing

- `docker compose -f compose.yml -f docker-compose.override.yml config`
- `docker compose -f compose.yml -f docker-compose.override.yml run --rm webguard-instance go test ./...`
- `git diff --check`
- `git diff --cached --check`

## Risks and follow-up

- This is documentation and governance only; no application code, dependencies, Docker files, or workflow files were changed.
- Tools without a committed supported adapter are governed directly through `AGENTS.md` and `.agent/skills/` until a supported adapter format is added.