### PR TITLE
feat(execution): add typed executor registry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -40,11 +40,11 @@ statuses, and result payloads. These types do not depend on transports.
 - `adapters/coreapi` implements the WebGuard Core HTTP client.
 - `adapters/health` provides liveness HTTP handlers and graceful server
   shutdown.
-- `adapters/runner` currently adapts the concrete HTTP, TLS, ping, TCP, and DNS checks
-  to the application phases.
+- `adapters/runner` registers independent HTTP, keyword, ping, TCP, DNS, TLS,
+  and domain-expiry executors. Each executor produces normalized result
+  payloads, which the shared publisher sends to Core.
 - `adapters/domainlookup` and `adapters/target` isolate RDAP/WHOIS and
   egress-policy details.
 
-The next migration step is to split `runner` into independently registered
-check executors. That change is deliberately separate so the new package
-boundaries remain compatible with the current API and behaviour.
+The next migration step is a bounded execution controller that applies global
+and per-executor concurrency limits without changing the Core API contract.

--- a/internal/adapters/runner/executor_registry.go
+++ b/internal/adapters/runner/executor_registry.go
@@ -1,0 +1,245 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/marcel-breuer/webguard-instance/internal/domain/monitor"
+)
+
+type ExecutionPhase string
+
+const (
+	PhaseResponse         ExecutionPhase = "response"
+	PhaseSSL              ExecutionPhase = "ssl"
+	PhaseDomainExpiration ExecutionPhase = "domain_expiration"
+)
+
+// Execution is the normalized output of one monitoring executor. The result
+// publisher translates populated payloads to the existing Core API endpoints.
+type Execution struct {
+	Response *monitor.MonitoringResponsePayload
+	SSL      *monitor.SSLResultPayload
+	Domain   *monitor.DomainResultPayload
+}
+
+// Executor owns one check concern. New monitor types are introduced by adding
+// and registering an executor instead of extending phase-specific switches.
+type Executor interface {
+	Name() string
+	Phase() ExecutionPhase
+	Types() []monitor.Type
+	Supports(monitor.Type) bool
+	Execute(context.Context, monitor.Monitoring) Execution
+}
+
+type executorRegistry struct {
+	executors []Executor
+}
+
+func newExecutorRegistry(executors ...Executor) *executorRegistry {
+	return &executorRegistry{executors: executors}
+}
+
+func (r *executorRegistry) Types(phase ExecutionPhase) []monitor.Type {
+	types := make([]monitor.Type, 0)
+	seen := make(map[monitor.Type]struct{})
+	for _, executor := range r.executors {
+		if executor.Phase() != phase {
+			continue
+		}
+		for _, monitoringType := range executor.Types() {
+			if _, ok := seen[monitoringType]; ok {
+				continue
+			}
+			seen[monitoringType] = struct{}{}
+			types = append(types, monitoringType)
+		}
+	}
+	return types
+}
+
+func (r *executorRegistry) Supports(phase ExecutionPhase, monitoringType monitor.Type) bool {
+	_, ok := r.find(phase, monitoringType)
+	return ok
+}
+
+func (r *executorRegistry) Execute(ctx context.Context, phase ExecutionPhase, monitoring monitor.Monitoring) (Execution, bool) {
+	executor, ok := r.find(phase, monitoring.Type)
+	if !ok {
+		return Execution{}, false
+	}
+	return executor.Execute(ctx, monitoring), true
+}
+
+func (r *executorRegistry) find(phase ExecutionPhase, monitoringType monitor.Type) (Executor, bool) {
+	for _, executor := range r.executors {
+		if executor.Phase() == phase && executor.Supports(monitoringType) {
+			return executor, true
+		}
+	}
+	return nil, false
+}
+
+type functionExecutor struct {
+	name            string
+	phase           ExecutionPhase
+	monitoringTypes []monitor.Type
+	execute         func(context.Context, monitor.Monitoring) Execution
+}
+
+func (e functionExecutor) Name() string {
+	return e.name
+}
+
+func (e functionExecutor) Phase() ExecutionPhase {
+	return e.phase
+}
+
+func (e functionExecutor) Types() []monitor.Type {
+	return append([]monitor.Type(nil), e.monitoringTypes...)
+}
+
+func (e functionExecutor) Supports(monitoringType monitor.Type) bool {
+	return slices.Contains(e.monitoringTypes, monitoringType)
+}
+
+func (e functionExecutor) Execute(ctx context.Context, monitoring monitor.Monitoring) Execution {
+	return e.execute(ctx, monitoring)
+}
+
+func (r *MonitoringService) newExecutorRegistry() *executorRegistry {
+	return newExecutorRegistry(
+		functionExecutor{
+			name:            "http",
+			phase:           PhaseResponse,
+			monitoringTypes: []monitor.Type{monitor.TypeHTTP},
+			execute:         r.executeHTTP,
+		},
+		functionExecutor{
+			name:            "ping",
+			phase:           PhaseResponse,
+			monitoringTypes: []monitor.Type{monitor.TypePing},
+			execute:         r.executePing,
+		},
+		functionExecutor{
+			name:            "keyword",
+			phase:           PhaseResponse,
+			monitoringTypes: []monitor.Type{monitor.TypeKeyword},
+			execute:         r.executeKeyword,
+		},
+		functionExecutor{
+			name:            "tcp-port",
+			phase:           PhaseResponse,
+			monitoringTypes: []monitor.Type{monitor.TypePort},
+			execute:         r.executePort,
+		},
+		functionExecutor{
+			name:            "dns-record",
+			phase:           PhaseResponse,
+			monitoringTypes: []monitor.Type{monitor.TypeDNSRecord},
+			execute:         r.executeDNSRecord,
+		},
+		functionExecutor{
+			name:            "tls-certificate",
+			phase:           PhaseSSL,
+			monitoringTypes: []monitor.Type{monitor.TypeHTTP, monitor.TypeKeyword, monitor.TypePort},
+			execute:         r.executeSSL,
+		},
+		functionExecutor{
+			name:            "domain-expiration",
+			phase:           PhaseDomainExpiration,
+			monitoringTypes: []monitor.Type{monitor.TypeDomainExpiration},
+			execute:         r.executeDomainExpiration,
+		},
+	)
+}
+
+func (r *MonitoringService) executeHTTP(ctx context.Context, monitoring monitor.Monitoring) Execution {
+	status, responseTime, httpStatusCode := r.handleHTTPMonitoring(ctx, monitoring)
+	return responseExecution(monitoring.ID, status, responseTime, httpStatusCode)
+}
+
+func (r *MonitoringService) executeKeyword(ctx context.Context, monitoring monitor.Monitoring) Execution {
+	status, responseTime, httpStatusCode := r.handleKeywordMonitoring(ctx, monitoring)
+	return responseExecution(monitoring.ID, status, responseTime, httpStatusCode)
+}
+
+func (r *MonitoringService) executePing(ctx context.Context, monitoring monitor.Monitoring) Execution {
+	status, responseTime := handlePingMonitoring(ctx, monitoring, r.egressPolicy(), r.pingExecutor)
+	return responseExecution(monitoring.ID, status, responseTime, nil)
+}
+
+func (r *MonitoringService) executePort(ctx context.Context, monitoring monitor.Monitoring) Execution {
+	status, responseTime := handlePortMonitoring(ctx, monitoring, r.egressPolicy())
+	return responseExecution(monitoring.ID, status, responseTime, nil)
+}
+
+func (r *MonitoringService) executeDNSRecord(ctx context.Context, monitoring monitor.Monitoring) Execution {
+	checker := r.dnsChecker
+	if checker == nil {
+		checker = NewDNSRecordChecker(nil, r.logger)
+	}
+	status, responseTime := checker.Check(ctx, monitoring)
+	return responseExecution(monitoring.ID, status, responseTime, nil)
+}
+
+func (r *MonitoringService) executeSSL(ctx context.Context, monitoring monitor.Monitoring) Execution {
+	payload := r.crawlMonitoringSSL(ctx, monitoring)
+	return Execution{SSL: &payload}
+}
+
+func (r *MonitoringService) executeDomainExpiration(ctx context.Context, monitoring monitor.Monitoring) Execution {
+	status, payload, hasPayload := r.crawlDomainExpiration(ctx, monitoring)
+	execution := responseExecution(monitoring.ID, status, nil, nil)
+	if hasPayload {
+		execution.Domain = &payload
+	}
+	return execution
+}
+
+func responseExecution(monitoringID string, status monitor.Status, responseTime *float64, httpStatusCode *int) Execution {
+	payload := monitor.MonitoringResponsePayload{
+		MonitoringID:   monitoringID,
+		Status:         status,
+		ResponseTime:   responseTime,
+		HTTPStatusCode: httpStatusCode,
+	}
+	return Execution{Response: &payload}
+}
+
+func maintenanceExecution(phase ExecutionPhase, monitoringID string) Execution {
+	if phase == PhaseSSL {
+		return Execution{}
+	}
+	return responseExecution(monitoringID, monitor.StatusUnknown, nil, nil)
+}
+
+func (r *MonitoringService) publishExecution(ctx context.Context, execution Execution) {
+	if execution.Response != nil {
+		if err := r.client.PostMonitoringResponse(ctx, *execution.Response); err != nil {
+			r.logger.Printf("Failed to post response result (monitoring_id=%s): %v", execution.Response.MonitoringID, err)
+		}
+	}
+	if execution.SSL != nil {
+		if err := r.client.PostSSLResult(ctx, *execution.SSL); err != nil {
+			r.logger.Printf("Failed to post SSL result (monitoring_id=%s): %v", execution.SSL.MonitoringID, err)
+		}
+	}
+	if execution.Domain != nil {
+		if err := r.client.PostDomainResult(ctx, *execution.Domain); err != nil {
+			r.logger.Printf("Failed to post domain expiration result (monitoring_id=%s): %v", execution.Domain.MonitoringID, err)
+		}
+	}
+}
+
+func (e Execution) String() string {
+	if e.Response != nil {
+		return fmt.Sprintf("status=%s response_time=%v http_status_code=%v", e.Response.Status, pointerFloat64Value(e.Response.ResponseTime), pointerIntValue(e.Response.HTTPStatusCode))
+	}
+	if e.SSL != nil {
+		return fmt.Sprintf("ssl_valid=%t", e.SSL.IsValid)
+	}
+	return "no result"
+}

--- a/internal/adapters/runner/executor_registry_test.go
+++ b/internal/adapters/runner/executor_registry_test.go
@@ -1,0 +1,71 @@
+package runner
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/marcel-breuer/webguard-instance/internal/domain/monitor"
+)
+
+func TestExecutorRegistryReturnsUniqueTypesInRegistrationOrder(t *testing.T) {
+	t.Parallel()
+
+	registry := newExecutorRegistry(
+		functionExecutor{
+			name:            "http",
+			phase:           PhaseResponse,
+			monitoringTypes: []monitor.Type{monitor.TypeHTTP, monitor.TypeKeyword},
+		},
+		functionExecutor{
+			name:            "keyword-extension",
+			phase:           PhaseResponse,
+			monitoringTypes: []monitor.Type{monitor.TypeKeyword, monitor.TypePing},
+		},
+		functionExecutor{
+			name:            "tls",
+			phase:           PhaseSSL,
+			monitoringTypes: []monitor.Type{monitor.TypeHTTP},
+		},
+	)
+
+	got := registry.Types(PhaseResponse)
+	want := []monitor.Type{monitor.TypeHTTP, monitor.TypeKeyword, monitor.TypePing}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unexpected response types: got %#v want %#v", got, want)
+	}
+
+	if registry.Supports(PhaseResponse, monitor.TypePort) {
+		t.Fatalf("expected port monitoring to be unsupported")
+	}
+	if !registry.Supports(PhaseSSL, monitor.TypeHTTP) {
+		t.Fatalf("expected HTTP SSL monitoring to be supported")
+	}
+}
+
+func TestExecutorRegistryExecutesOnlyMatchingPhaseAndType(t *testing.T) {
+	t.Parallel()
+
+	executed := false
+	registry := newExecutorRegistry(functionExecutor{
+		name:            "ping",
+		phase:           PhaseResponse,
+		monitoringTypes: []monitor.Type{monitor.TypePing},
+		execute: func(_ context.Context, monitoring monitor.Monitoring) Execution {
+			executed = true
+			return responseExecution(monitoring.ID, monitor.StatusUp, nil, nil)
+		},
+	})
+
+	execution, ok := registry.Execute(context.Background(), PhaseResponse, monitor.Monitoring{
+		ID:   "ping-1",
+		Type: monitor.TypePing,
+	})
+	if !ok || !executed || execution.Response == nil || execution.Response.Status != monitor.StatusUp {
+		t.Fatalf("expected matching executor response, got %#v", execution)
+	}
+
+	if _, ok := registry.Execute(context.Background(), PhaseSSL, monitor.Monitoring{Type: monitor.TypePing}); ok {
+		t.Fatalf("expected phase mismatch to remain unhandled")
+	}
+}

--- a/internal/adapters/runner/runner.go
+++ b/internal/adapters/runner/runner.go
@@ -37,28 +37,20 @@ const fixedPingTimeoutSeconds = 5
 
 var pingLatencyPattern = regexp.MustCompile(`time[=<]([0-9]+(?:\.[0-9]+)?)\s*ms`)
 
-var pingExecutor = runPingCommand
-
-var responseMonitoringTypes = []monitor.Type{
-	monitor.TypeHTTP,
-	monitor.TypePing,
-	monitor.TypeKeyword,
-	monitor.TypePort,
-	monitor.TypeDNSRecord,
-}
-
-var sslMonitoringTypes = []monitor.Type{
-	monitor.TypeHTTP,
-	monitor.TypeKeyword,
-	monitor.TypePort,
-}
-
-var domainExpirationMonitoringTypes = []monitor.Type{
-	monitor.TypeDomainExpiration,
-}
-
 type DomainLookup interface {
 	Lookup(ctx context.Context, target string) (domainlookup.Result, error)
+}
+
+type PingCommandExecutor func(context.Context, string, int) ([]byte, error)
+
+type HTTPChecker interface {
+	Check(context.Context, monitor.Monitoring) (int, string, error)
+}
+
+type HTTPCheckFunc func(context.Context, monitor.Monitoring) (int, string, error)
+
+func (f HTTPCheckFunc) Check(ctx context.Context, monitoring monitor.Monitoring) (int, string, error) {
+	return f(ctx, monitoring)
 }
 
 type MonitoringService struct {
@@ -67,25 +59,32 @@ type MonitoringService struct {
 	logger       *log.Logger
 	domainLookup DomainLookup
 	dnsChecker   *DNSRecordChecker
+	pingExecutor PingCommandExecutor
+	httpChecker  HTTPChecker
+	executors    *executorRegistry
 }
 
 func New(client application.MonitoringGateway, cfg config.Config, logger *log.Logger) *MonitoringService {
 	if logger == nil {
 		logger = log.New(io.Discard, "", 0)
 	}
-	return &MonitoringService{
+	service := &MonitoringService{
 		client:       client,
 		cfg:          cfg,
 		logger:       logger,
 		domainLookup: domainlookup.New(10 * time.Second),
 		dnsChecker:   NewDNSRecordChecker(nil, logger),
+		pingExecutor: runPingCommand,
 	}
+	service.httpChecker = HTTPCheckFunc(service.performHTTPRequest)
+	service.executors = service.newExecutorRegistry()
+	return service
 }
 
 func (r *MonitoringService) runResponse(ctx context.Context) error {
 	r.logger.Println("Dispatching response monitoring jobs...")
 
-	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, responseMonitoringTypes)
+	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, r.executors.Types(PhaseResponse))
 	if err != nil {
 		r.logFetchError(err)
 		return err
@@ -109,29 +108,20 @@ func (r *MonitoringService) runResponse(ctx context.Context) error {
 		go func() {
 			defer workers.Done()
 			for monitoring := range jobs {
-				status, responseTime, httpStatusCode := r.crawlResponseMonitoring(ctx, monitoring)
+				execution, _ := r.executors.Execute(ctx, PhaseResponse, monitoring)
 				r.logger.Printf(
-					"Response monitoring result computed (monitoring_id=%s type=%s status=%s response_time=%v http_status_code=%v)",
+					"Response monitoring result computed (monitoring_id=%s type=%s %s)",
 					monitoring.ID,
 					monitoring.Type,
-					status,
-					pointerFloat64Value(responseTime),
-					pointerIntValue(httpStatusCode),
+					execution,
 				)
-				if err := r.client.PostMonitoringResponse(ctx, monitor.MonitoringResponsePayload{
-					MonitoringID:   monitoring.ID,
-					Status:         status,
-					ResponseTime:   responseTime,
-					HTTPStatusCode: httpStatusCode,
-				}); err != nil {
-					r.logger.Printf("Failed to post response result (monitoring_id=%s): %v", monitoring.ID, err)
-				}
+				r.publishExecution(ctx, execution)
 			}
 		}()
 	}
 
 	for _, monitoring := range monitorings {
-		if !supportsResponseChecks(monitoring.Type) {
+		if !r.executors.Supports(PhaseResponse, monitoring.Type) {
 			skippedUnsupported++
 			r.logger.Printf(
 				"Skipping passive/unsupported response monitoring (monitoring_id=%s type=%s)",
@@ -143,14 +133,7 @@ func (r *MonitoringService) runResponse(ctx context.Context) error {
 
 		if monitoring.MaintenanceActive {
 			skippedMaintenance++
-			if err := r.client.PostMonitoringResponse(ctx, monitor.MonitoringResponsePayload{
-				MonitoringID:   monitoring.ID,
-				Status:         monitor.StatusUnknown,
-				ResponseTime:   nil,
-				HTTPStatusCode: nil,
-			}); err != nil {
-				r.logger.Printf("Failed to post maintenance response result (monitoring_id=%s): %v", monitoring.ID, err)
-			}
+			r.publishExecution(ctx, maintenanceExecution(PhaseResponse, monitoring.ID))
 			continue
 		}
 
@@ -174,7 +157,7 @@ func (r *MonitoringService) runResponse(ctx context.Context) error {
 func (r *MonitoringService) runSSL(ctx context.Context) error {
 	r.logger.Println("Dispatching SSL monitoring jobs...")
 
-	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, sslMonitoringTypes)
+	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, r.executors.Types(PhaseSSL))
 	if err != nil {
 		r.logFetchError(err)
 		return err
@@ -198,16 +181,14 @@ func (r *MonitoringService) runSSL(ctx context.Context) error {
 		go func() {
 			defer workers.Done()
 			for monitoring := range jobs {
-				payload := r.crawlMonitoringSSL(ctx, monitoring)
-				if err := r.client.PostSSLResult(ctx, payload); err != nil {
-					r.logger.Printf("Failed to post SSL result (monitoring_id=%s): %v", monitoring.ID, err)
-				}
+				execution, _ := r.executors.Execute(ctx, PhaseSSL, monitoring)
+				r.publishExecution(ctx, execution)
 			}
 		}()
 	}
 
 	for _, monitoring := range monitorings {
-		if !supportsSSLChecks(monitoring.Type) {
+		if !r.executors.Supports(PhaseSSL, monitoring.Type) {
 			skippedUnsupported++
 			r.logger.Printf(
 				"Skipping passive/unsupported SSL monitoring (monitoring_id=%s type=%s)",
@@ -241,7 +222,7 @@ func (r *MonitoringService) runSSL(ctx context.Context) error {
 func (r *MonitoringService) runDomainExpiration(ctx context.Context) error {
 	r.logger.Println("Dispatching domain expiration monitoring jobs...")
 
-	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, domainExpirationMonitoringTypes)
+	monitorings, err := r.client.GetMonitorings(ctx, r.cfg.WebGuardLocation, r.executors.Types(PhaseDomainExpiration))
 	if err != nil {
 		r.logFetchError(err)
 		return err
@@ -265,31 +246,19 @@ func (r *MonitoringService) runDomainExpiration(ctx context.Context) error {
 		go func() {
 			defer workers.Done()
 			for monitoring := range jobs {
-				status, domainPayload, hasDomainPayload := r.crawlDomainExpiration(ctx, monitoring)
+				execution, _ := r.executors.Execute(ctx, PhaseDomainExpiration, monitoring)
 				r.logger.Printf(
-					"Domain expiration monitoring result computed (monitoring_id=%s status=%s)",
+					"Domain expiration monitoring result computed (monitoring_id=%s %s)",
 					monitoring.ID,
-					status,
+					execution,
 				)
-				if err := r.client.PostMonitoringResponse(ctx, monitor.MonitoringResponsePayload{
-					MonitoringID:   monitoring.ID,
-					Status:         status,
-					ResponseTime:   nil,
-					HTTPStatusCode: nil,
-				}); err != nil {
-					r.logger.Printf("Failed to post domain expiration response result (monitoring_id=%s): %v", monitoring.ID, err)
-				}
-				if hasDomainPayload {
-					if err := r.client.PostDomainResult(ctx, domainPayload); err != nil {
-						r.logger.Printf("Failed to post domain expiration result (monitoring_id=%s): %v", monitoring.ID, err)
-					}
-				}
+				r.publishExecution(ctx, execution)
 			}
 		}()
 	}
 
 	for _, monitoring := range monitorings {
-		if monitoring.Type != monitor.TypeDomainExpiration {
+		if !r.executors.Supports(PhaseDomainExpiration, monitoring.Type) {
 			skippedUnsupported++
 			r.logger.Printf(
 				"Skipping unsupported domain expiration monitoring (monitoring_id=%s type=%s)",
@@ -301,14 +270,7 @@ func (r *MonitoringService) runDomainExpiration(ctx context.Context) error {
 
 		if monitoring.MaintenanceActive {
 			skippedMaintenance++
-			if err := r.client.PostMonitoringResponse(ctx, monitor.MonitoringResponsePayload{
-				MonitoringID:   monitoring.ID,
-				Status:         monitor.StatusUnknown,
-				ResponseTime:   nil,
-				HTTPStatusCode: nil,
-			}); err != nil {
-				r.logger.Printf("Failed to post maintenance domain expiration response result (monitoring_id=%s): %v", monitoring.ID, err)
-			}
+			r.publishExecution(ctx, maintenanceExecution(PhaseDomainExpiration, monitoring.ID))
 			continue
 		}
 
@@ -362,52 +324,16 @@ func (r *MonitoringService) logFetchError(err error) {
 }
 
 func (r *MonitoringService) crawlResponseMonitoring(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64, *int) {
-	switch monitoring.Type {
-	case monitor.TypeHTTP:
-		return r.handleHTTPMonitoring(ctx, monitoring)
-	case monitor.TypePing:
-		status, responseTime := handlePingMonitoring(ctx, monitoring, r.egressPolicy())
-		return status, responseTime, nil
-	case monitor.TypeKeyword:
-		return r.handleKeywordMonitoring(ctx, monitoring)
-	case monitor.TypePort:
-		status, responseTime := handlePortMonitoring(ctx, monitoring, r.egressPolicy())
-		return status, responseTime, nil
-	case monitor.TypeDNSRecord:
-		checker := r.dnsChecker
-		if checker == nil {
-			checker = NewDNSRecordChecker(nil, r.logger)
-		}
-		status, responseTime := checker.Check(ctx, monitoring)
-		return status, responseTime, nil
-	case monitor.TypeHeartbeat:
-		return monitor.StatusUnknown, nil, nil
-	default:
+	execution, ok := r.executors.Execute(ctx, PhaseResponse, monitoring)
+	if !ok || execution.Response == nil {
 		return monitor.StatusUnknown, nil, nil
 	}
-}
-
-func supportsResponseChecks(monitoringType monitor.Type) bool {
-	switch monitoringType {
-	case monitor.TypeHTTP, monitor.TypePing, monitor.TypeKeyword, monitor.TypePort, monitor.TypeDNSRecord:
-		return true
-	default:
-		return false
-	}
-}
-
-func supportsSSLChecks(monitoringType monitor.Type) bool {
-	switch monitoringType {
-	case monitor.TypeHTTP, monitor.TypeKeyword, monitor.TypePort:
-		return true
-	default:
-		return false
-	}
+	return execution.Response.Status, execution.Response.ResponseTime, execution.Response.HTTPStatusCode
 }
 
 func (r *MonitoringService) handleHTTPMonitoring(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64, *int) {
 	start := time.Now()
-	statusCode, _, err := r.performHTTPRequest(ctx, monitoring)
+	statusCode, _, err := r.httpCheck(ctx, monitoring)
 	if err != nil {
 		return monitor.StatusDown, nil, nil
 	}
@@ -421,7 +347,7 @@ func (r *MonitoringService) handleHTTPMonitoring(ctx context.Context, monitoring
 
 func (r *MonitoringService) handleKeywordMonitoring(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64, *int) {
 	start := time.Now()
-	statusCode, body, err := r.performHTTPRequest(ctx, monitoring)
+	statusCode, body, err := r.httpCheck(ctx, monitoring)
 	if err != nil {
 		return monitor.StatusDown, nil, nil
 	}
@@ -433,11 +359,19 @@ func (r *MonitoringService) handleKeywordMonitoring(ctx context.Context, monitor
 	return monitor.StatusDown, nil, httpStatusCode
 }
 
+func (r *MonitoringService) httpCheck(ctx context.Context, monitoring monitor.Monitoring) (int, string, error) {
+	checker := r.httpChecker
+	if checker == nil {
+		checker = HTTPCheckFunc(r.performHTTPRequest)
+	}
+	return checker.Check(ctx, monitoring)
+}
+
 func (r *MonitoringService) egressPolicy() target.EgressPolicy {
 	return target.EgressPolicy{AllowPrivate: r.cfg.AllowPrivateTargets}
 }
 
-func handlePingMonitoring(ctx context.Context, monitoring monitor.Monitoring, policy target.EgressPolicy) (monitor.Status, *float64) {
+func handlePingMonitoring(ctx context.Context, monitoring monitor.Monitoring, policy target.EgressPolicy, executor PingCommandExecutor) (monitor.Status, *float64) {
 	host, err := target.Host(monitoring.Target)
 	if err != nil {
 		return monitor.StatusDown, nil
@@ -452,7 +386,10 @@ func handlePingMonitoring(ctx context.Context, monitoring monitor.Monitoring, po
 	}
 
 	start := time.Now()
-	output, err := pingExecutor(context.Background(), host, timeoutSeconds)
+	if executor == nil {
+		executor = runPingCommand
+	}
+	output, err := executor(ctx, host, timeoutSeconds)
 	responseTime := parsePingLatency(output)
 	if responseTime == nil {
 		elapsed := roundMilliseconds(time.Since(start))

--- a/internal/adapters/runner/runner_logic_test.go
+++ b/internal/adapters/runner/runner_logic_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -83,6 +84,31 @@ func TestNormalizeBody(t *testing.T) {
 	body = normalizeBody("invalid-json")
 	if string(body) != "[]" {
 		t.Fatalf("expected fallback body [] for invalid JSON string, got %s", string(body))
+	}
+}
+
+func TestHTTPAndKeywordExecutorsShareInjectedHTTPChecker(t *testing.T) {
+	t.Parallel()
+
+	var calls []monitor.Type
+	r := New(nil, config.Config{AllowPrivateTargets: true}, log.New(io.Discard, "", 0))
+	r.httpChecker = HTTPCheckFunc(func(_ context.Context, monitoring monitor.Monitoring) (int, string, error) {
+		calls = append(calls, monitoring.Type)
+		return http.StatusOK, "expected keyword", nil
+	})
+
+	for _, monitoring := range []monitor.Monitoring{
+		{ID: "http-1", Type: monitor.TypeHTTP},
+		{ID: "keyword-1", Type: monitor.TypeKeyword, Keyword: "keyword"},
+	} {
+		execution, ok := r.executors.Execute(context.Background(), PhaseResponse, monitoring)
+		if !ok || execution.Response == nil || execution.Response.Status != monitor.StatusUp {
+			t.Fatalf("expected successful execution for %s, got %#v", monitoring.Type, execution)
+		}
+	}
+
+	if !slices.Equal(calls, []monitor.Type{monitor.TypeHTTP, monitor.TypeKeyword}) {
+		t.Fatalf("unexpected checker calls: %#v", calls)
 	}
 }
 
@@ -353,11 +379,6 @@ func TestPerformHTTPRequestRetriesOnTransportError(t *testing.T) {
 }
 
 func TestHandlePingMonitoringSupportsHostnameAndIPTargets(t *testing.T) {
-	originalExecutor := pingExecutor
-	t.Cleanup(func() {
-		pingExecutor = originalExecutor
-	})
-
 	testCases := []struct {
 		name   string
 		target string
@@ -372,16 +393,16 @@ func TestHandlePingMonitoringSupportsHostnameAndIPTargets(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			var receivedHost string
 			var receivedTimeout int
-			pingExecutor = func(_ context.Context, host string, timeoutSeconds int) ([]byte, error) {
+			executor := PingCommandExecutor(func(_ context.Context, host string, timeoutSeconds int) ([]byte, error) {
 				receivedHost = host
 				receivedTimeout = timeoutSeconds
 				return []byte("64 bytes from " + host + ": icmp_seq=1 ttl=57 time=12.34 ms"), nil
-			}
+			})
 
 			status, responseTime := handlePingMonitoring(context.Background(), monitor.Monitoring{
 				Target:  testCase.target,
 				Timeout: 2,
-			}, target.EgressPolicy{AllowPrivate: true})
+			}, target.EgressPolicy{AllowPrivate: true}, executor)
 
 			if status != monitor.StatusUp {
 				t.Fatalf("expected up, got %s", status)
@@ -403,18 +424,13 @@ func TestHandlePingMonitoringSupportsHostnameAndIPTargets(t *testing.T) {
 }
 
 func TestHandlePingMonitoringDown(t *testing.T) {
-	originalExecutor := pingExecutor
-	t.Cleanup(func() {
-		pingExecutor = originalExecutor
-	})
-
-	pingExecutor = func(_ context.Context, _ string, _ int) ([]byte, error) {
+	executor := PingCommandExecutor(func(_ context.Context, _ string, _ int) ([]byte, error) {
 		return []byte("100% packet loss"), errors.New("exit status 1")
-	}
+	})
 
 	status, responseTime := handlePingMonitoring(context.Background(), monitor.Monitoring{
 		Target: "8.8.8.8",
-	}, target.EgressPolicy{AllowPrivate: true})
+	}, target.EgressPolicy{AllowPrivate: true}, executor)
 	if status != monitor.StatusDown {
 		t.Fatalf("expected down, got %s", status)
 	}

--- a/internal/adapters/runner/runner_test.go
+++ b/internal/adapters/runner/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -43,10 +44,10 @@ func (f *fakeCoreClient) GetMonitorings(_ context.Context, location string, type
 	})
 	f.mu.Unlock()
 
-	if len(types) == len(responseMonitoringTypes) {
+	if slices.Contains(types, monitor.TypePing) || slices.Contains(types, monitor.TypeDNSRecord) {
 		return append([]monitor.Monitoring(nil), f.responseMonitorings...), nil
 	}
-	if len(types) == len(domainExpirationMonitoringTypes) && types[0] == monitor.TypeDomainExpiration {
+	if slices.Contains(types, monitor.TypeDomainExpiration) {
 		return append([]monitor.Monitoring(nil), f.domainMonitorings...), nil
 	}
 
@@ -410,10 +411,10 @@ type parallelPhasesClient struct {
 
 func (p *parallelPhasesClient) GetMonitorings(_ context.Context, _ string, types []monitor.Type) ([]monitor.Monitoring, error) {
 	phase := "ssl"
-	if len(types) == len(responseMonitoringTypes) {
+	if slices.Contains(types, monitor.TypePing) || slices.Contains(types, monitor.TypeDNSRecord) {
 		phase = "response"
 	}
-	if len(types) == len(domainExpirationMonitoringTypes) && types[0] == monitor.TypeDomainExpiration {
+	if slices.Contains(types, monitor.TypeDomainExpiration) {
 		phase = "domain"
 	}
 	p.started <- phase


### PR DESCRIPTION
## What changed

- Added typed monitoring executors with phase, capability, and normalized-result contracts.
- Registered HTTP, keyword, ping, TCP, DNS, TLS, and domain-expiry executors in one registry.
- Centralized supported-type discovery, maintenance responses, and Core result publication.
- Replaced the mutable package-level ping test hook with an injected command executor and introduced a shared injected HTTP checker for HTTP and keyword checks.
- Updated the architecture document for the executor-based design.

## Why

Monitoring types previously required edits to multiple phase switches and worker paths. A registry makes each check independently testable and confines new type support to executor implementation plus registration.

## Validation

- Docker development-image build
- `go test ./...`
- `go test -cover ./...`
- `go test -count=10 ./internal/adapters/runner ./internal/adapters/scheduler ./internal/application`
- `go vet ./...`

`go test -race ./...` was attempted but cannot build because the Alpine development image has no `gcc`.

Closes #31.