### PR TITLE
feat: support Core instance API paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 WEBGUARD_LOCATION=
 WEBGUARD_CORE_API_KEY=
 WEBGUARD_CORE_API_URL=
+# Core #593 instance contract (v1): use /api/v1/internal only for legacy Core deployments.
+WEBGUARD_INSTANCE_API_BASE_PATH=/api/v1/internal/instances
 
 QUEUE_DEFAULT_WORKERS=3
 RUN_MAX_CONCURRENCY=3

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,9 @@ statuses, and result payloads. These types do not depend on transports.
 
 ## Adapters
 
-- `adapters/coreapi` implements the WebGuard Core HTTP client.
+- `adapters/coreapi` implements Core instance-contract `v1`. It owns the
+  configurable target (`/api/v1/internal/instances`) and legacy
+  (`/api/v1/internal`) base paths so runner code cannot access UI routes.
 - `adapters/health` provides liveness HTTP handlers and graceful server
   shutdown, readiness, and a Prometheus-compatible operations endpoint.
 - `adapters/runner` registers independent HTTP, keyword, ping, TCP, DNS, TLS,

--- a/JOB_LEASE_PROTOCOL.md
+++ b/JOB_LEASE_PROTOCOL.md
@@ -2,7 +2,7 @@
 
 This protocol lets multiple WebGuard Instances serve the same location without
 deliberately executing one active monitoring job twice. It is versioned by its
-`/api/v1/internal` path and is opt-in in the instance through
+Core instance-contract `v1` path and is opt-in in the instance through
 `WEBGUARD_JOB_LEASES_ENABLED`.
 
 ## Core contract
@@ -13,10 +13,10 @@ the location code.
 
 | Operation | Endpoint | Worker request | Core response or effect |
 | --- | --- | --- | --- |
-| Claim | `POST /api/v1/internal/monitoring-jobs/claim` | `location`, `instance_id`, `capabilities`, `capacity`, `max_batch_size` | `jobs`, each with `job_id`, `phase`, `lease_expires_at`, `attempt`, `idempotency_key`, and a monitoring snapshot |
-| Complete | `POST /api/v1/internal/monitoring-jobs/{job_id}/complete` | `attempt` and one normalized `result` | Completes the lease and records the result once for the `Idempotency-Key` header |
-| Extend | `POST /api/v1/internal/monitoring-jobs/{job_id}/extend` | `attempt` | Returns the new `lease_expires_at` when a long-running check needs more time |
-| Release | `POST /api/v1/internal/monitoring-jobs/{job_id}/release` | `attempt` and a machine-readable reason | Makes a job eligible for later placement without recording a result |
+| Claim | `POST {instance API base path}/monitoring-jobs/claim` | `location`, `instance_id`, `capabilities`, `capacity`, `max_batch_size` | `jobs`, each with `job_id`, `phase`, `lease_expires_at`, `attempt`, `idempotency_key`, and a monitoring snapshot |
+| Complete | `POST {instance API base path}/monitoring-jobs/{job_id}/complete` | `attempt` and one normalized `result` | Completes the lease and records the result once for the `Idempotency-Key` header |
+| Extend | `POST {instance API base path}/monitoring-jobs/{job_id}/extend` | `attempt` | Returns the new `lease_expires_at` when a long-running check needs more time |
+| Release | `POST {instance API base path}/monitoring-jobs/{job_id}/release` | `attempt` and a machine-readable reason | Makes a job eligible for later placement without recording a result |
 
 `phase` is one of `response`, `ssl`, or `domain_expiration`. This makes the
 existing response and certificate checks for one monitoring separate schedulable

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ The current package boundaries and dependency rule are documented in
 ## Features
 
 - **Core-Compatible API Contract**
-  - `GET /api/v1/internal/monitorings`
-  - `POST /api/v1/internal/monitoring-responses`
-  - `POST /api/v1/internal/ssl-results`
-  - `POST /api/v1/internal/domain-results`
+  - Core instance contract `v1` at `GET /api/v1/internal/instances/monitorings`
+  - `POST /api/v1/internal/instances/monitoring-responses`
+  - `POST /api/v1/internal/instances/ssl-results`
+  - `POST /api/v1/internal/instances/domain-results`
   - Feature-flagged lease protocol: claim, complete, and release monitoring jobs
   - `X-INSTANCE-CODE` + `X-API-KEY` header authentication
 - **Parallel Monitoring Execution**
@@ -90,6 +90,7 @@ Main integration settings:
 - `WEBGUARD_LOCATION` (instance code used for `location` query and `X-INSTANCE-CODE` header)
 - `WEBGUARD_CORE_API_KEY`
 - `WEBGUARD_CORE_API_URL`
+- `WEBGUARD_INSTANCE_API_BASE_PATH` (default: `/api/v1/internal/instances`; set `/api/v1/internal` only for the documented legacy compatibility window)
 
 Runtime settings:
 
@@ -107,6 +108,11 @@ See `.env.example` for full defaults.
 
 The contract and rollout sequence for horizontally scaled workers are in
 [the monitoring job lease protocol](JOB_LEASE_PROTOCOL.md).
+
+The supported Core scanner contract is `v1`, published by WebGuard Core as the
+[WebGuard Instance API contract](https://github.com/marcel-breuer/webguard/blob/main/docs/integrations/webguard-instance-api.md).
+The adapter accepts only its target instance path and the documented legacy
+path; it never calls browser UI routes.
 
 ## Operations
 

--- a/cmd/webguard-instance/main.go
+++ b/cmd/webguard-instance/main.go
@@ -27,7 +27,7 @@ func main() {
 	logger := log.New(os.Stdout, "", 0)
 	cfg := config.FromEnv()
 	telemetry := application.NewTelemetry()
-	coreClient := coreapi.NewClient(cfg.WebGuardCoreAPIURL, cfg.WebGuardCoreAPIKey, cfg.WebGuardLocation)
+	coreClient := coreapi.NewClientWithInstanceAPIPath(cfg.WebGuardCoreAPIURL, cfg.WebGuardCoreAPIKey, cfg.WebGuardLocation, cfg.WebGuardInstanceAPIBasePath)
 	coreClient.SetTelemetry(telemetry)
 	service := application.NewExecutionControllerWithTelemetry(runner.NewWithTelemetry(coreClient, cfg, logger, telemetry), logger, cfg.RunMaxConcurrency, telemetry)
 

--- a/internal/adapters/coreapi/client.go
+++ b/internal/adapters/coreapi/client.go
@@ -15,14 +15,24 @@ import (
 	"github.com/marcel-breuer/webguard-instance/internal/domain/monitor"
 )
 
-const maxResponseBodyBytes = 4 << 20
+const (
+	maxResponseBodyBytes = 4 << 20
+
+	// SupportedContractVersion is the versioned Core instance contract from
+	// WebGuard Core #593. The path is independently configurable during its
+	// documented compatibility window.
+	SupportedContractVersion   = "v1"
+	DefaultInstanceAPIBasePath = "/api/v1/internal/instances"
+	LegacyInstanceAPIBasePath  = "/api/v1/internal"
+)
 
 type Client struct {
-	baseURL      string
-	apiKey       string
-	instanceCode string
-	httpClient   *http.Client
-	telemetry    *application.Telemetry
+	baseURL         string
+	apiKey          string
+	instanceCode    string
+	instanceAPIPath string
+	httpClient      *http.Client
+	telemetry       *application.Telemetry
 }
 
 type HTTPStatusError struct {
@@ -36,13 +46,31 @@ func (e *HTTPStatusError) Error() string {
 
 func NewClient(baseURL, apiKey, instanceCode string) *Client {
 	return &Client{
-		baseURL:      strings.TrimRight(baseURL, "/"),
-		apiKey:       strings.TrimSpace(apiKey),
-		instanceCode: strings.TrimSpace(instanceCode),
+		baseURL:         strings.TrimRight(baseURL, "/"),
+		apiKey:          strings.TrimSpace(apiKey),
+		instanceCode:    strings.TrimSpace(instanceCode),
+		instanceAPIPath: DefaultInstanceAPIBasePath,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
 	}
+}
+
+func NewClientWithInstanceAPIPath(baseURL, apiKey, instanceCode, instanceAPIPath string) *Client {
+	client := NewClient(baseURL, apiKey, instanceCode)
+	if err := client.SetInstanceAPIPath(instanceAPIPath); err != nil {
+		client.instanceAPIPath = ""
+	}
+	return client
+}
+
+func (c *Client) SetInstanceAPIPath(instanceAPIPath string) error {
+	normalized, err := normalizeInstanceAPIPath(instanceAPIPath)
+	if err != nil {
+		return err
+	}
+	c.instanceAPIPath = normalized
+	return nil
 }
 
 func (c *Client) SetHTTPClient(httpClient *http.Client) {
@@ -105,7 +133,7 @@ func (c *Client) getMonitorings(ctx context.Context, location string, monitoring
 		query.Set("type", string(monitoringType))
 	}
 
-	request, err := c.newRequest(ctx, http.MethodGet, "/api/v1/internal/monitorings", query, nil)
+	request, err := c.newRequest(ctx, http.MethodGet, c.instanceAPIEndpoint("/monitorings"), query, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +146,7 @@ func (c *Client) getMonitorings(ctx context.Context, location string, monitoring
 }
 
 func (c *Client) PostMonitoringResponse(ctx context.Context, payload monitor.MonitoringResponsePayload) error {
-	request, err := c.newRequest(ctx, http.MethodPost, "/api/v1/internal/monitoring-responses", nil, payload)
+	request, err := c.newRequest(ctx, http.MethodPost, c.instanceAPIEndpoint("/monitoring-responses"), nil, payload)
 	if err != nil {
 		return err
 	}
@@ -127,7 +155,7 @@ func (c *Client) PostMonitoringResponse(ctx context.Context, payload monitor.Mon
 }
 
 func (c *Client) PostSSLResult(ctx context.Context, payload monitor.SSLResultPayload) error {
-	request, err := c.newRequest(ctx, http.MethodPost, "/api/v1/internal/ssl-results", nil, payload)
+	request, err := c.newRequest(ctx, http.MethodPost, c.instanceAPIEndpoint("/ssl-results"), nil, payload)
 	if err != nil {
 		return err
 	}
@@ -136,7 +164,7 @@ func (c *Client) PostSSLResult(ctx context.Context, payload monitor.SSLResultPay
 }
 
 func (c *Client) PostDomainResult(ctx context.Context, payload monitor.DomainResultPayload) error {
-	request, err := c.newRequest(ctx, http.MethodPost, "/api/v1/internal/domain-results", nil, payload)
+	request, err := c.newRequest(ctx, http.MethodPost, c.instanceAPIEndpoint("/domain-results"), nil, payload)
 	if err != nil {
 		return err
 	}
@@ -158,7 +186,7 @@ func (c *Client) ClaimMonitoringJobs(ctx context.Context, payload monitor.ClaimM
 		return nil, fmt.Errorf("claim max batch size must be positive")
 	}
 
-	request, err := c.newRequest(ctx, http.MethodPost, "/api/v1/internal/monitoring-jobs/claim", nil, payload)
+	request, err := c.newRequest(ctx, http.MethodPost, c.instanceAPIEndpoint("/monitoring-jobs/claim"), nil, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +205,7 @@ func (c *Client) CompleteMonitoringJob(ctx context.Context, jobID, idempotencyKe
 	if strings.TrimSpace(idempotencyKey) == "" {
 		return fmt.Errorf("job idempotency key is empty")
 	}
-	request, err := c.newRequest(ctx, http.MethodPost, "/api/v1/internal/monitoring-jobs/"+url.PathEscape(jobID)+"/complete", nil, payload)
+	request, err := c.newRequest(ctx, http.MethodPost, c.instanceAPIEndpoint("/monitoring-jobs/"+url.PathEscape(jobID)+"/complete"), nil, payload)
 	if err != nil {
 		return err
 	}
@@ -189,7 +217,7 @@ func (c *Client) ReleaseMonitoringJob(ctx context.Context, jobID string, payload
 	if strings.TrimSpace(jobID) == "" {
 		return fmt.Errorf("job ID is empty")
 	}
-	request, err := c.newRequest(ctx, http.MethodPost, "/api/v1/internal/monitoring-jobs/"+url.PathEscape(jobID)+"/release", nil, payload)
+	request, err := c.newRequest(ctx, http.MethodPost, c.instanceAPIEndpoint("/monitoring-jobs/"+url.PathEscape(jobID)+"/release"), nil, payload)
 	if err != nil {
 		return err
 	}
@@ -200,7 +228,7 @@ func (c *Client) ExtendMonitoringJob(ctx context.Context, jobID string, payload 
 	if strings.TrimSpace(jobID) == "" {
 		return monitor.ExtendMonitoringJobResponse{}, fmt.Errorf("job ID is empty")
 	}
-	request, err := c.newRequest(ctx, http.MethodPost, "/api/v1/internal/monitoring-jobs/"+url.PathEscape(jobID)+"/extend", nil, payload)
+	request, err := c.newRequest(ctx, http.MethodPost, c.instanceAPIEndpoint("/monitoring-jobs/"+url.PathEscape(jobID)+"/extend"), nil, payload)
 	if err != nil {
 		return monitor.ExtendMonitoringJobResponse{}, err
 	}
@@ -214,6 +242,9 @@ func (c *Client) ExtendMonitoringJob(ctx context.Context, jobID string, payload 
 func (c *Client) newRequest(ctx context.Context, method, path string, query url.Values, body any) (*http.Request, error) {
 	if c.baseURL == "" {
 		return nil, fmt.Errorf("WEBGUARD_CORE_API_URL is empty")
+	}
+	if c.instanceAPIPath == "" {
+		return nil, fmt.Errorf("WEBGUARD_INSTANCE_API_BASE_PATH is invalid")
 	}
 
 	endpoint, err := url.Parse(c.baseURL + path)
@@ -249,6 +280,20 @@ func (c *Client) newRequest(ctx context.Context, method, path string, query url.
 	}
 
 	return request, nil
+}
+
+func (c *Client) instanceAPIEndpoint(suffix string) string {
+	return c.instanceAPIPath + suffix
+}
+
+func normalizeInstanceAPIPath(instanceAPIPath string) (string, error) {
+	normalized := "/" + strings.Trim(strings.TrimSpace(instanceAPIPath), "/")
+	switch normalized {
+	case DefaultInstanceAPIBasePath, LegacyInstanceAPIBasePath:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("unsupported WEBGUARD_INSTANCE_API_BASE_PATH %q", instanceAPIPath)
+	}
 }
 
 func (c *Client) doJSON(request *http.Request, out any, operation string) (resultErr error) {

--- a/internal/adapters/coreapi/client_test.go
+++ b/internal/adapters/coreapi/client_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ func TestGetMonitoringsIncludesHeadersAndQuery(t *testing.T) {
 		gotLocation = request.URL.Query().Get("location")
 		gotType = request.URL.Query().Get("type")
 
-		if request.URL.Path != "/api/v1/internal/monitorings" {
+		if request.URL.Path != "/api/v1/internal/instances/monitorings" {
 			t.Fatalf("unexpected path: %s", request.URL.Path)
 		}
 
@@ -79,6 +80,66 @@ func TestClientRecordsBoundedCoreRequestTelemetry(t *testing.T) {
 	metric := telemetry.Snapshot().Core["get_monitorings"]
 	if metric.Count != 1 || metric.Errors != 1 || metric.Duration < 0 {
 		t.Fatalf("unexpected Core telemetry: %#v", metric)
+	}
+}
+
+func TestClientSupportsConfiguredLegacyAndTargetInstancePaths(t *testing.T) {
+	t.Parallel()
+
+	for _, instanceAPIPath := range []string{DefaultInstanceAPIBasePath, LegacyInstanceAPIBasePath} {
+		instanceAPIPath := instanceAPIPath
+		t.Run(instanceAPIPath, func(t *testing.T) {
+			var paths []string
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.Header.Get("X-API-KEY") != "secret-key" || request.Header.Get("X-INSTANCE-CODE") != "de-1" {
+					t.Fatalf("missing instance authentication headers")
+				}
+				paths = append(paths, request.URL.Path)
+				if request.URL.Path == instanceAPIPath+"/monitorings" {
+					writer.Header().Set("Content-Type", "application/json")
+					_, _ = writer.Write([]byte(`[]`))
+					return
+				}
+				writer.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			client := NewClientWithInstanceAPIPath(server.URL, "secret-key", "de-1", instanceAPIPath)
+			if _, err := client.GetMonitorings(context.Background(), "de-1", nil); err != nil {
+				t.Fatalf("GetMonitorings failed: %v", err)
+			}
+			if err := client.PostMonitoringResponse(context.Background(), monitor.MonitoringResponsePayload{MonitoringID: "1", Status: monitor.StatusUp}); err != nil {
+				t.Fatalf("PostMonitoringResponse failed: %v", err)
+			}
+			if err := client.PostSSLResult(context.Background(), monitor.SSLResultPayload{MonitoringID: "1", IsValid: true}); err != nil {
+				t.Fatalf("PostSSLResult failed: %v", err)
+			}
+			if err := client.PostDomainResult(context.Background(), monitor.DomainResultPayload{MonitoringID: "1", IsValid: true}); err != nil {
+				t.Fatalf("PostDomainResult failed: %v", err)
+			}
+			expectedPaths := []string{
+				instanceAPIPath + "/monitorings",
+				instanceAPIPath + "/monitoring-responses",
+				instanceAPIPath + "/ssl-results",
+				instanceAPIPath + "/domain-results",
+			}
+			if !slices.Equal(paths, expectedPaths) {
+				t.Fatalf("unexpected instance paths: got %v, want %v", paths, expectedPaths)
+			}
+		})
+	}
+}
+
+func TestClientRejectsUnsupportedInstancePath(t *testing.T) {
+	t.Parallel()
+
+	client := NewClient("https://core.example.test", "secret-key", "de-1")
+	if err := client.SetInstanceAPIPath("/api/v1/internal/ui"); err == nil {
+		t.Fatal("expected UI path to be rejected")
+	}
+	client = NewClientWithInstanceAPIPath("https://core.example.test", "secret-key", "de-1", "/api/v1/internal/ui")
+	if _, err := client.GetMonitorings(context.Background(), "de-1", nil); err == nil || !strings.Contains(err.Error(), "INSTANCE_API_BASE_PATH") {
+		t.Fatalf("expected invalid configured path error, got %v", err)
 	}
 }
 
@@ -186,24 +247,24 @@ func TestClaimAndCompleteMonitoringJobsUseLeaseContract(t *testing.T) {
 			t.Fatalf("expected POST, got %s", request.Method)
 		}
 		switch request.URL.Path {
-		case "/api/v1/internal/monitoring-jobs/claim":
+		case "/api/v1/internal/instances/monitoring-jobs/claim":
 			if err := json.NewDecoder(request.Body).Decode(&claim); err != nil {
 				t.Fatalf("decode claim: %v", err)
 			}
 			writer.Header().Set("Content-Type", "application/json")
 			_, _ = writer.Write([]byte(`{"jobs":[{"job_id":"job-1","phase":"response","lease_expires_at":"2026-07-26T12:00:00Z","attempt":3,"idempotency_key":"key-1","monitoring":{"id":"42","type":"http","target":"https://example.com","timeout":10}}]}`))
-		case "/api/v1/internal/monitoring-jobs/job-1/complete":
+		case "/api/v1/internal/instances/monitoring-jobs/job-1/complete":
 			completionKey = request.Header.Get("Idempotency-Key")
 			if err := json.NewDecoder(request.Body).Decode(&completion); err != nil {
 				t.Fatalf("decode completion: %v", err)
 			}
 			writer.WriteHeader(http.StatusNoContent)
-		case "/api/v1/internal/monitoring-jobs/job-1/release":
+		case "/api/v1/internal/instances/monitoring-jobs/job-1/release":
 			if err := json.NewDecoder(request.Body).Decode(&release); err != nil {
 				t.Fatalf("decode release: %v", err)
 			}
 			writer.WriteHeader(http.StatusNoContent)
-		case "/api/v1/internal/monitoring-jobs/job-1/extend":
+		case "/api/v1/internal/instances/monitoring-jobs/job-1/extend":
 			if err := json.NewDecoder(request.Body).Decode(&extend); err != nil {
 				t.Fatalf("decode extend: %v", err)
 			}
@@ -284,7 +345,7 @@ func TestPostMonitoringResponsePayloadShape(t *testing.T) {
 	var body map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/api/v1/internal/monitoring-responses" {
+		if request.URL.Path != "/api/v1/internal/instances/monitoring-responses" {
 			t.Fatalf("unexpected path: %s", request.URL.Path)
 		}
 
@@ -330,7 +391,7 @@ func TestPostMonitoringResponsePayloadIncludesHTTPStatusCode(t *testing.T) {
 	var body map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/api/v1/internal/monitoring-responses" {
+		if request.URL.Path != "/api/v1/internal/instances/monitoring-responses" {
 			t.Fatalf("unexpected path: %s", request.URL.Path)
 		}
 		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
@@ -363,7 +424,7 @@ func TestPostSSLResultPayloadShape(t *testing.T) {
 	var body map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/api/v1/internal/ssl-results" {
+		if request.URL.Path != "/api/v1/internal/instances/ssl-results" {
 			t.Fatalf("unexpected path: %s", request.URL.Path)
 		}
 
@@ -409,7 +470,7 @@ func TestPostDomainResultPayloadShape(t *testing.T) {
 	var body map[string]any
 
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path != "/api/v1/internal/domain-results" {
+		if request.URL.Path != "/api/v1/internal/instances/domain-results" {
 			t.Fatalf("unexpected path: %s", request.URL.Path)
 		}
 

--- a/internal/adapters/runner/runner_logic_test.go
+++ b/internal/adapters/runner/runner_logic_test.go
@@ -1036,14 +1036,14 @@ func TestRunDomainExpirationUsesCoreAPIEndpoints(t *testing.T) {
 		}
 
 		switch {
-		case request.Method == http.MethodGet && request.URL.Path == "/api/v1/internal/monitorings":
+		case request.Method == http.MethodGet && request.URL.Path == "/api/v1/internal/instances/monitorings":
 			if request.URL.Query().Get("location") != "de-1" || request.URL.Query().Get("type") != "domain_expiration" {
 				http.Error(writer, "unexpected query", http.StatusBadRequest)
 				return
 			}
 			writer.Header().Set("Content-Type", "application/json")
 			_, _ = writer.Write([]byte(`[{"id":"domain-api","type":"domain_expiration","target":"example.com","maintenance_active":false}]`))
-		case request.Method == http.MethodPost && request.URL.Path == "/api/v1/internal/monitoring-responses":
+		case request.Method == http.MethodPost && request.URL.Path == "/api/v1/internal/instances/monitoring-responses":
 			var payload monitor.MonitoringResponsePayload
 			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
 				http.Error(writer, err.Error(), http.StatusBadRequest)
@@ -1051,7 +1051,7 @@ func TestRunDomainExpirationUsesCoreAPIEndpoints(t *testing.T) {
 			}
 			responseCh <- payload
 			writer.WriteHeader(http.StatusNoContent)
-		case request.Method == http.MethodPost && request.URL.Path == "/api/v1/internal/domain-results":
+		case request.Method == http.MethodPost && request.URL.Path == "/api/v1/internal/instances/domain-results":
 			var payload monitor.DomainResultPayload
 			if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
 				http.Error(writer, err.Error(), http.StatusBadRequest)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Config struct {
-	WebGuardCoreAPIKey string
-	WebGuardCoreAPIURL string
-	WebGuardLocation   string
-	WebGuardInstanceID string
+	WebGuardCoreAPIKey          string
+	WebGuardCoreAPIURL          string
+	WebGuardInstanceAPIBasePath string
+	WebGuardLocation            string
+	WebGuardInstanceID          string
 
 	QueueDefaultWorkers  int
 	RunMaxConcurrency    int
@@ -28,10 +29,11 @@ func FromEnv() Config {
 	port := env("PORT", "8080")
 	drainTimeoutSeconds := max(1, envInt("SHUTDOWN_DRAIN_TIMEOUT_SECONDS", 10))
 	return Config{
-		WebGuardCoreAPIKey: env("WEBGUARD_CORE_API_KEY", ""),
-		WebGuardCoreAPIURL: env("WEBGUARD_CORE_API_URL", ""),
-		WebGuardLocation:   env("WEBGUARD_LOCATION", ""),
-		WebGuardInstanceID: env("WEBGUARD_INSTANCE_ID", ""),
+		WebGuardCoreAPIKey:          env("WEBGUARD_CORE_API_KEY", ""),
+		WebGuardCoreAPIURL:          env("WEBGUARD_CORE_API_URL", ""),
+		WebGuardInstanceAPIBasePath: env("WEBGUARD_INSTANCE_API_BASE_PATH", "/api/v1/internal/instances"),
+		WebGuardLocation:            env("WEBGUARD_LOCATION", ""),
+		WebGuardInstanceID:          env("WEBGUARD_INSTANCE_ID", ""),
 
 		QueueDefaultWorkers:  envInt("QUEUE_DEFAULT_WORKERS", 3),
 		RunMaxConcurrency:    envInt("RUN_MAX_CONCURRENCY", envInt("QUEUE_DEFAULT_WORKERS", 3)),
@@ -49,7 +51,15 @@ func (c Config) IsReady() bool {
 	if strings.TrimSpace(c.WebGuardCoreAPIKey) == "" || strings.TrimSpace(c.WebGuardCoreAPIURL) == "" || strings.TrimSpace(c.WebGuardLocation) == "" {
 		return false
 	}
+	if !isSupportedInstanceAPIBasePath(c.WebGuardInstanceAPIBasePath) {
+		return false
+	}
 	return !c.JobLeasesEnabled || strings.TrimSpace(c.WebGuardInstanceID) != ""
+}
+
+func isSupportedInstanceAPIBasePath(path string) bool {
+	normalized := "/" + strings.Trim(strings.TrimSpace(path), "/")
+	return normalized == "/api/v1/internal/instances" || normalized == "/api/v1/internal"
 }
 
 func env(key, fallback string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,7 @@ func TestFromEnvDefaults(t *testing.T) {
 	t.Setenv("BIND_ADDRESS", "")
 	t.Setenv("WEBGUARD_CORE_API_KEY", "")
 	t.Setenv("WEBGUARD_CORE_API_URL", "")
+	t.Setenv("WEBGUARD_INSTANCE_API_BASE_PATH", "")
 	t.Setenv("WEBGUARD_LOCATION", "")
 	t.Setenv("WEBGUARD_INSTANCE_ID", "")
 	t.Setenv("QUEUE_DEFAULT_WORKERS", "")
@@ -31,6 +32,9 @@ func TestFromEnvDefaults(t *testing.T) {
 	if cfg.RunMaxConcurrency != 3 {
 		t.Fatalf("expected default max concurrency 3, got %d", cfg.RunMaxConcurrency)
 	}
+	if cfg.WebGuardInstanceAPIBasePath != "/api/v1/internal/instances" {
+		t.Fatalf("expected default instance API base path, got %q", cfg.WebGuardInstanceAPIBasePath)
+	}
 	if cfg.AllowPrivateTargets {
 		t.Fatalf("expected private targets to be disabled by default")
 	}
@@ -50,6 +54,7 @@ func TestFromEnvCustomValues(t *testing.T) {
 	t.Setenv("BIND_ADDRESS", "127.0.0.1:9191")
 	t.Setenv("WEBGUARD_CORE_API_KEY", "key")
 	t.Setenv("WEBGUARD_CORE_API_URL", "https://core.example.com")
+	t.Setenv("WEBGUARD_INSTANCE_API_BASE_PATH", "/api/v1/internal")
 	t.Setenv("WEBGUARD_LOCATION", "de-1")
 	t.Setenv("WEBGUARD_INSTANCE_ID", "worker-de-1-a")
 	t.Setenv("QUEUE_DEFAULT_WORKERS", "7")
@@ -70,6 +75,9 @@ func TestFromEnvCustomValues(t *testing.T) {
 	}
 	if cfg.WebGuardCoreAPIURL != "https://core.example.com" {
 		t.Fatalf("unexpected core url: %q", cfg.WebGuardCoreAPIURL)
+	}
+	if cfg.WebGuardInstanceAPIBasePath != "/api/v1/internal" {
+		t.Fatalf("unexpected instance API base path: %q", cfg.WebGuardInstanceAPIBasePath)
 	}
 	if cfg.WebGuardLocation != "de-1" {
 		t.Fatalf("unexpected location: %q", cfg.WebGuardLocation)
@@ -100,7 +108,7 @@ func TestFromEnvCustomValues(t *testing.T) {
 func TestConfigReadinessRequiresCoreConfigurationAndLeaseIdentity(t *testing.T) {
 	t.Parallel()
 
-	ready := Config{WebGuardCoreAPIKey: "key", WebGuardCoreAPIURL: "https://core.example.test", WebGuardLocation: "de-1"}
+	ready := Config{WebGuardCoreAPIKey: "key", WebGuardCoreAPIURL: "https://core.example.test", WebGuardInstanceAPIBasePath: "/api/v1/internal/instances", WebGuardLocation: "de-1"}
 	if !ready.IsReady() {
 		t.Fatal("expected legacy configuration to be ready")
 	}
@@ -114,6 +122,10 @@ func TestConfigReadinessRequiresCoreConfigurationAndLeaseIdentity(t *testing.T) 
 	ready.WebGuardInstanceID = "worker-de-1-a"
 	if !ready.IsReady() {
 		t.Fatal("expected complete lease configuration to be ready")
+	}
+	ready.WebGuardInstanceAPIBasePath = "/api/v1/internal/ui"
+	if ready.IsReady() {
+		t.Fatal("expected UI path to be rejected for an instance")
 	}
 }
 


### PR DESCRIPTION
## What changed

- consumes Core #593's instance-contract v1 and defaults all Core API calls to `/api/v1/internal/instances`
- adds `WEBGUARD_INSTANCE_API_BASE_PATH` for the documented legacy compatibility path `/api/v1/internal`
- centralizes every Core path in the Core API adapter, including the feature-flagged lease endpoints; monitoring execution code remains path-agnostic
- rejects browser UI paths and documents the supported contract and rollout behavior

Closes #35.

## Why

WebGuard Core now separates browser UI and scanner-instance APIs. Instances need an explicit, configurable path during the compatibility window without risking calls to UI routes.

## Validation

- Docker: `go test ./...`
- Docker: `go test -cover ./...`
- Docker: `go test -count=10 ./internal/adapters/coreapi ./internal/adapters/runner ./internal/adapters/scheduler`
- Docker: `go vet ./...`
- Docker production image build
- added target/legacy path, authentication, payload, response-decoding, invalid-path, and existing non-success contract coverage

## Compatibility

The adapter supports only Core contract v1 target and legacy paths. The legacy route remains opt-in through configuration until the coordinated Core rollout condition is met. No incident callback is migrated because this instance currently has no incident caller.