### PR TITLE
feat: send raw monitoring observations for derived health

### DIFF
--- a/MONITORING_OBSERVATION_CONTRACT.md
+++ b/MONITORING_OBSERVATION_CONTRACT.md
@@ -1,0 +1,55 @@
+# Monitoring observation contract
+
+This document defines the additive scanner-to-Core payload used by issue #42.
+It applies to `POST /api/v1/internal/instances/monitoring-responses` and the
+legacy equivalent `POST /api/v1/internal/monitoring-responses`.
+
+## Compatibility
+
+Every response keeps the existing `monitoring_id`, `status`, `response_time`,
+and `http_status_code` fields. Core versions that only read those fields can
+continue to process the callback. New workers additionally send `observation`.
+
+The authenticated instance route family, `X-INSTANCE-CODE`, `X-API-KEY`, and
+the existing bounded retry and idempotency behavior are unchanged.
+
+## Payload
+
+```json
+{
+  "monitoring_id": "monitoring-1",
+  "status": "up",
+  "response_time": 42.5,
+  "http_status_code": 200,
+  "observation": {
+    "type": "http",
+    "observed_at": "2026-08-02T08:00:00Z",
+    "http_status_code": 200,
+    "response_time": 42.5
+  }
+}
+```
+
+`observation` is omitted for maintenance/legacy-only payload construction. The
+worker never includes an underlying transport error message; it sends a stable
+failure category instead.
+
+The observation fields are:
+
+| Field | Meaning |
+| --- | --- |
+| `type` | Monitoring type that produced the observation. |
+| `observed_at` | UTC timestamp at which the check started. |
+| `http_status_code` | HTTP status received by an HTTP or keyword check. |
+| `response_time` | Elapsed milliseconds only when a response or connection was obtained. It is omitted for failed requests. |
+| `transport_error` | Stable category such as `http_transport_error`, `ping_failed`, `connection_failed`, or `dns_lookup_failed`. |
+| `connected` | Whether ping or TCP-port connection succeeded. |
+| `keyword_matched` | Whether a keyword check found its configured keyword. The keyword itself is never relayed. |
+| `dns_record_type` | DNS record type queried. |
+| `dns_expected_values` | Normalized configured DNS values. |
+| `dns_observed_values` | Normalized values returned by the resolver. |
+| `dns_matched` | Whether observed DNS values matched the configured values. |
+| `metadata` | Small type-specific values that are safe to expose, currently the TCP port. |
+
+Core can derive `up`, `down`, and `unknown` from these observations while
+evaluating latency independently for reachable HTTP and keyword checks.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The current package boundaries and dependency rule are documented in
   - `POST /api/v1/internal/instances/monitoring-responses`
   - `POST /api/v1/internal/instances/ssl-results`
   - `POST /api/v1/internal/instances/domain-results`
+  - additive raw observations for derived health; see
+    [the monitoring observation contract](MONITORING_OBSERVATION_CONTRACT.md)
   - Feature-flagged lease protocol: claim, complete, and release monitoring jobs
   - `X-INSTANCE-CODE` + `X-API-KEY` header authentication
 - **Parallel Monitoring Execution**

--- a/internal/adapters/coreapi/client_test.go
+++ b/internal/adapters/coreapi/client_test.go
@@ -417,6 +417,55 @@ func TestPostMonitoringResponsePayloadIncludesHTTPStatusCode(t *testing.T) {
 	}
 }
 
+func TestPostMonitoringResponsePayloadIncludesRawObservation(t *testing.T) {
+	t.Parallel()
+
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/api/v1/internal/instances/monitoring-responses" {
+			t.Fatalf("unexpected path: %s", request.URL.Path)
+		}
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			t.Fatalf("failed to decode payload: %v", err)
+		}
+		writer.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	responseTime := 123.45
+	statusCode := http.StatusOK
+	connected := true
+	client := NewClient(server.URL, "secret-key", "de-1")
+	err := client.PostMonitoringResponse(context.Background(), monitor.MonitoringResponsePayload{
+		MonitoringID: "42",
+		Status:       monitor.StatusUp,
+		Observation: &monitor.RawObservation{
+			Type:           monitor.TypeHTTP,
+			ObservedAt:     time.Date(2026, 8, 2, 8, 0, 0, 0, time.UTC),
+			HTTPStatusCode: &statusCode,
+			ResponseTime:   &responseTime,
+			Connected:      &connected,
+		},
+	})
+	if err != nil {
+		t.Fatalf("PostMonitoringResponse failed: %v", err)
+	}
+
+	observation, ok := body["observation"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected observation object, got %#v", body["observation"])
+	}
+	if observation["type"] != string(monitor.TypeHTTP) {
+		t.Fatalf("expected observation type http, got %#v", observation["type"])
+	}
+	if observation["http_status_code"] != float64(http.StatusOK) {
+		t.Fatalf("expected observation http status 200, got %#v", observation["http_status_code"])
+	}
+	if observation["response_time"] != responseTime {
+		t.Fatalf("expected observation response time %v, got %#v", responseTime, observation["response_time"])
+	}
+}
+
 func TestPostSSLResultPayloadShape(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapters/runner/dns_record_checker.go
+++ b/internal/adapters/runner/dns_record_checker.go
@@ -41,24 +41,41 @@ func (c *DNSRecordChecker) Supports(monitoringType monitor.Type) bool {
 }
 
 func (c *DNSRecordChecker) Check(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64) {
+	status, responseTime, _ := c.Observe(ctx, monitoring)
+	return status, responseTime
+}
+
+func (c *DNSRecordChecker) Observe(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64, monitor.RawObservation) {
 	start := time.Now()
+	observation := monitor.RawObservation{
+		Type:              monitoring.Type,
+		ObservedAt:        start.UTC(),
+		DNSRecordType:     strings.TrimSpace(monitoring.DNSRecordType),
+		DNSExpectedValues: append([]string(nil), monitoring.DNSExpectedValues...),
+	}
 	responseTime := func() *float64 {
 		elapsed := roundMilliseconds(time.Since(start))
+		observation.ResponseTime = &elapsed
 		return &elapsed
+	}
+	failed := func(reason string) (monitor.Status, *float64, monitor.RawObservation) {
+		observation.TransportError = stringPointer(reason)
+		return monitor.StatusDown, nil, observation
 	}
 
 	target := strings.TrimSpace(monitoring.Target)
 	recordType := strings.TrimSpace(monitoring.DNSRecordType)
 	if target == "" || recordType == "" || len(monitoring.DNSExpectedValues) == 0 {
 		c.logf("Invalid DNS monitoring configuration for %s %s: target/type/expected values are required", target, recordType)
-		return monitor.StatusDown, responseTime()
+		return failed("invalid_configuration")
 	}
 
 	expected, err := normalizeDNSRecordValues(monitoring.DNSExpectedValues, recordType)
 	if err != nil {
 		c.logf("Invalid expected DNS values for %s %s: %v", target, recordType, err)
-		return monitor.StatusDown, responseTime()
+		return failed("invalid_expected_values")
 	}
+	observation.DNSExpectedValues = expected
 
 	timeout := fixedDNSTimeoutSeconds * time.Second
 	if monitoring.Timeout > 0 {
@@ -68,21 +85,24 @@ func (c *DNSRecordChecker) Check(ctx context.Context, monitoring monitor.Monitor
 	actualRaw, err := c.resolver.Resolve(ctx, target, recordType, timeout)
 	if err != nil {
 		c.logf("DNS lookup failed for %s %s: %v", target, recordType, err)
-		return monitor.StatusDown, responseTime()
+		return failed("dns_lookup_failed")
 	}
 
 	actual, err := normalizeDNSRecordValues(actualRaw, recordType)
 	if err != nil {
 		c.logf("Invalid DNS response values for %s %s: %v", target, recordType, err)
-		return monitor.StatusDown, responseTime()
+		return failed("invalid_observed_values")
 	}
+	observation.DNSObservedValues = actual
+	matched := slices.Equal(actual, expected)
+	observation.DNSMatched = boolPointer(matched)
 
-	if slices.Equal(actual, expected) {
-		return monitor.StatusUp, responseTime()
+	if matched {
+		return monitor.StatusUp, responseTime(), observation
 	}
 
 	c.logf("DNS mismatch for %s %s\nexpected: %q\nactual: %q", target, recordType, expected, actual)
-	return monitor.StatusDown, responseTime()
+	return monitor.StatusDown, responseTime(), observation
 }
 
 func (c *DNSRecordChecker) logf(format string, args ...any) {

--- a/internal/adapters/runner/executor_registry.go
+++ b/internal/adapters/runner/executor_registry.go
@@ -157,23 +157,23 @@ func (r *MonitoringService) newExecutorRegistry() *executorRegistry {
 }
 
 func (r *MonitoringService) executeHTTP(ctx context.Context, monitoring monitor.Monitoring) Execution {
-	status, responseTime, httpStatusCode := r.handleHTTPMonitoring(ctx, monitoring)
-	return responseExecution(monitoring.ID, status, responseTime, httpStatusCode)
+	status, responseTime, httpStatusCode, observation := r.observeHTTPMonitoring(ctx, monitoring)
+	return responseExecutionWithObservation(monitoring.ID, status, responseTime, httpStatusCode, &observation)
 }
 
 func (r *MonitoringService) executeKeyword(ctx context.Context, monitoring monitor.Monitoring) Execution {
-	status, responseTime, httpStatusCode := r.handleKeywordMonitoring(ctx, monitoring)
-	return responseExecution(monitoring.ID, status, responseTime, httpStatusCode)
+	status, responseTime, httpStatusCode, observation := r.observeKeywordMonitoring(ctx, monitoring)
+	return responseExecutionWithObservation(monitoring.ID, status, responseTime, httpStatusCode, &observation)
 }
 
 func (r *MonitoringService) executePing(ctx context.Context, monitoring monitor.Monitoring) Execution {
-	status, responseTime := handlePingMonitoring(ctx, monitoring, r.egressPolicy(), r.pingExecutor)
-	return responseExecution(monitoring.ID, status, responseTime, nil)
+	status, responseTime, observation := observePingMonitoring(ctx, monitoring, r.egressPolicy(), r.pingExecutor)
+	return responseExecutionWithObservation(monitoring.ID, status, responseTime, nil, &observation)
 }
 
 func (r *MonitoringService) executePort(ctx context.Context, monitoring monitor.Monitoring) Execution {
-	status, responseTime := handlePortMonitoring(ctx, monitoring, r.egressPolicy())
-	return responseExecution(monitoring.ID, status, responseTime, nil)
+	status, responseTime, observation := observePortMonitoring(ctx, monitoring, r.egressPolicy())
+	return responseExecutionWithObservation(monitoring.ID, status, responseTime, nil, &observation)
 }
 
 func (r *MonitoringService) executeDNSRecord(ctx context.Context, monitoring monitor.Monitoring) Execution {
@@ -181,8 +181,8 @@ func (r *MonitoringService) executeDNSRecord(ctx context.Context, monitoring mon
 	if checker == nil {
 		checker = NewDNSRecordChecker(nil, r.logger)
 	}
-	status, responseTime := checker.Check(ctx, monitoring)
-	return responseExecution(monitoring.ID, status, responseTime, nil)
+	status, responseTime, observation := checker.Observe(ctx, monitoring)
+	return responseExecutionWithObservation(monitoring.ID, status, responseTime, nil, &observation)
 }
 
 func (r *MonitoringService) executeSSL(ctx context.Context, monitoring monitor.Monitoring) Execution {
@@ -200,11 +200,16 @@ func (r *MonitoringService) executeDomainExpiration(ctx context.Context, monitor
 }
 
 func responseExecution(monitoringID string, status monitor.Status, responseTime *float64, httpStatusCode *int) Execution {
+	return responseExecutionWithObservation(monitoringID, status, responseTime, httpStatusCode, nil)
+}
+
+func responseExecutionWithObservation(monitoringID string, status monitor.Status, responseTime *float64, httpStatusCode *int, observation *monitor.RawObservation) Execution {
 	payload := monitor.MonitoringResponsePayload{
 		MonitoringID:   monitoringID,
 		Status:         status,
 		ResponseTime:   responseTime,
 		HTTPStatusCode: httpStatusCode,
+		Observation:    observation,
 	}
 	return Execution{Response: &payload}
 }

--- a/internal/adapters/runner/runner.go
+++ b/internal/adapters/runner/runner.go
@@ -365,31 +365,52 @@ func (r *MonitoringService) crawlResponseMonitoring(ctx context.Context, monitor
 }
 
 func (r *MonitoringService) handleHTTPMonitoring(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64, *int) {
+	status, responseTime, httpStatusCode, _ := r.observeHTTPMonitoring(ctx, monitoring)
+	return status, responseTime, httpStatusCode
+}
+
+func (r *MonitoringService) observeHTTPMonitoring(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64, *int, monitor.RawObservation) {
 	start := time.Now()
+	observation := monitor.RawObservation{Type: monitoring.Type, ObservedAt: start.UTC()}
 	statusCode, _, err := r.httpCheck(ctx, monitoring)
 	if err != nil {
-		return monitor.StatusDown, nil, nil
+		observation.TransportError = stringPointer("http_transport_error")
+		return monitor.StatusDown, nil, nil, observation
 	}
 	httpStatusCode := intPointer(statusCode)
+	responseTime := roundMilliseconds(time.Since(start))
+	observation.HTTPStatusCode = httpStatusCode
+	observation.ResponseTime = &responseTime
 	if statusCode >= http.StatusOK && statusCode < http.StatusBadRequest {
-		responseTime := roundMilliseconds(time.Since(start))
-		return monitor.StatusUp, &responseTime, httpStatusCode
+		return monitor.StatusUp, &responseTime, httpStatusCode, observation
 	}
-	return monitor.StatusDown, nil, httpStatusCode
+	return monitor.StatusDown, nil, httpStatusCode, observation
 }
 
 func (r *MonitoringService) handleKeywordMonitoring(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64, *int) {
+	status, responseTime, httpStatusCode, _ := r.observeKeywordMonitoring(ctx, monitoring)
+	return status, responseTime, httpStatusCode
+}
+
+func (r *MonitoringService) observeKeywordMonitoring(ctx context.Context, monitoring monitor.Monitoring) (monitor.Status, *float64, *int, monitor.RawObservation) {
 	start := time.Now()
+	observation := monitor.RawObservation{Type: monitoring.Type, ObservedAt: start.UTC()}
 	statusCode, body, err := r.httpCheck(ctx, monitoring)
 	if err != nil {
-		return monitor.StatusDown, nil, nil
+		observation.TransportError = stringPointer("http_transport_error")
+		observation.KeywordMatched = boolPointer(false)
+		return monitor.StatusDown, nil, nil, observation
 	}
 	httpStatusCode := intPointer(statusCode)
-	if strings.Contains(body, monitoring.Keyword) {
-		responseTime := roundMilliseconds(time.Since(start))
-		return monitor.StatusUp, &responseTime, httpStatusCode
+	responseTime := roundMilliseconds(time.Since(start))
+	matched := strings.Contains(body, monitoring.Keyword)
+	observation.HTTPStatusCode = httpStatusCode
+	observation.ResponseTime = &responseTime
+	observation.KeywordMatched = boolPointer(matched)
+	if matched {
+		return monitor.StatusUp, &responseTime, httpStatusCode, observation
 	}
-	return monitor.StatusDown, nil, httpStatusCode
+	return monitor.StatusDown, nil, httpStatusCode, observation
 }
 
 func (r *MonitoringService) httpCheck(ctx context.Context, monitoring monitor.Monitoring) (int, string, error) {
@@ -405,12 +426,21 @@ func (r *MonitoringService) egressPolicy() target.EgressPolicy {
 }
 
 func handlePingMonitoring(ctx context.Context, monitoring monitor.Monitoring, policy target.EgressPolicy, executor PingCommandExecutor) (monitor.Status, *float64) {
+	status, responseTime, _ := observePingMonitoring(ctx, monitoring, policy, executor)
+	return status, responseTime
+}
+
+func observePingMonitoring(ctx context.Context, monitoring monitor.Monitoring, policy target.EgressPolicy, executor PingCommandExecutor) (monitor.Status, *float64, monitor.RawObservation) {
+	start := time.Now()
+	observation := monitor.RawObservation{Type: monitoring.Type, ObservedAt: start.UTC(), Connected: boolPointer(false)}
 	host, err := target.Host(monitoring.Target)
 	if err != nil {
-		return monitor.StatusDown, nil
+		observation.TransportError = stringPointer("invalid_target")
+		return monitor.StatusDown, nil, observation
 	}
 	if err := target.ValidateHost(ctx, host, policy); err != nil {
-		return monitor.StatusDown, nil
+		observation.TransportError = stringPointer("target_rejected")
+		return monitor.StatusDown, nil, observation
 	}
 
 	timeoutSeconds := fixedPingTimeoutSeconds
@@ -418,21 +448,23 @@ func handlePingMonitoring(ctx context.Context, monitoring monitor.Monitoring, po
 		timeoutSeconds = monitoring.Timeout
 	}
 
-	start := time.Now()
 	if executor == nil {
 		executor = runPingCommand
 	}
 	output, err := executor(ctx, host, timeoutSeconds)
 	responseTime := parsePingLatency(output)
+	if err != nil {
+		observation.TransportError = stringPointer("ping_failed")
+		return monitor.StatusDown, nil, observation
+	}
+
 	if responseTime == nil {
 		elapsed := roundMilliseconds(time.Since(start))
 		responseTime = &elapsed
 	}
-	if err != nil {
-		return monitor.StatusDown, responseTime
-	}
-
-	return monitor.StatusUp, responseTime
+	observation.Connected = boolPointer(true)
+	observation.ResponseTime = responseTime
+	return monitor.StatusUp, responseTime, observation
 }
 
 func runPingCommand(ctx context.Context, host string, timeoutSeconds int) ([]byte, error) {
@@ -479,26 +511,42 @@ func parsePingLatency(output []byte) *float64 {
 }
 
 func handlePortMonitoring(ctx context.Context, monitoring monitor.Monitoring, policy target.EgressPolicy) (monitor.Status, *float64) {
+	status, responseTime, _ := observePortMonitoring(ctx, monitoring, policy)
+	return status, responseTime
+}
+
+func observePortMonitoring(ctx context.Context, monitoring monitor.Monitoring, policy target.EgressPolicy) (monitor.Status, *float64, monitor.RawObservation) {
+	start := time.Now()
+	observation := monitor.RawObservation{
+		Type:       monitoring.Type,
+		ObservedAt: start.UTC(),
+		Connected:  boolPointer(false),
+		Metadata:   map[string]string{"port": strconv.Itoa(monitoring.Port)},
+	}
 	if monitoring.Port <= 0 {
-		return monitor.StatusDown, nil
+		observation.TransportError = stringPointer("invalid_port")
+		return monitor.StatusDown, nil, observation
 	}
 
 	address, err := target.TCPAddress(monitoring.Target, monitoring.Port)
 	if err != nil {
-		return monitor.StatusDown, nil
+		observation.TransportError = stringPointer("invalid_target")
+		return monitor.StatusDown, nil, observation
 	}
 
-	start := time.Now()
 	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	conn, err := target.SafeDialContext(policy)(dialCtx, "tcp", address)
 	if err != nil {
-		return monitor.StatusDown, nil
+		observation.TransportError = stringPointer("connection_failed")
+		return monitor.StatusDown, nil, observation
 	}
 	_ = conn.Close()
 
 	responseTime := roundMilliseconds(time.Since(start))
-	return monitor.StatusUp, &responseTime
+	observation.Connected = boolPointer(true)
+	observation.ResponseTime = &responseTime
+	return monitor.StatusUp, &responseTime, observation
 }
 
 func (r *MonitoringService) performHTTPRequest(ctx context.Context, monitoring monitor.Monitoring) (int, string, error) {
@@ -757,6 +805,14 @@ func roundMilliseconds(duration time.Duration) float64 {
 }
 
 func intPointer(value int) *int {
+	return &value
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func stringPointer(value string) *string {
 	return &value
 }
 

--- a/internal/adapters/runner/runner_logic_test.go
+++ b/internal/adapters/runner/runner_logic_test.go
@@ -112,6 +112,72 @@ func TestHTTPAndKeywordExecutorsShareInjectedHTTPChecker(t *testing.T) {
 	}
 }
 
+func TestResponseExecutorsPreserveFailureEvidenceWithoutResponseTime(t *testing.T) {
+	t.Parallel()
+
+	r := New(nil, config.Config{AllowPrivateTargets: true}, log.New(io.Discard, "", 0))
+	r.httpChecker = HTTPCheckFunc(func(context.Context, monitor.Monitoring) (int, string, error) {
+		return 0, "", errors.New("connection refused")
+	})
+	r.pingExecutor = func(context.Context, string, int) ([]byte, error) {
+		return []byte("100% packet loss"), errors.New("exit status 1")
+	}
+
+	cases := []struct {
+		name       string
+		monitoring monitor.Monitoring
+		assert     func(*testing.T, monitor.RawObservation)
+	}{
+		{
+			name:       "http transport failure",
+			monitoring: monitor.Monitoring{ID: "http-failed", Type: monitor.TypeHTTP},
+			assert: func(t *testing.T, observation monitor.RawObservation) {
+				if observation.TransportError == nil || *observation.TransportError != "http_transport_error" {
+					t.Fatalf("expected HTTP transport error, got %#v", observation.TransportError)
+				}
+			},
+		},
+		{
+			name:       "ping failure",
+			monitoring: monitor.Monitoring{ID: "ping-failed", Type: monitor.TypePing, Target: "8.8.8.8"},
+			assert: func(t *testing.T, observation monitor.RawObservation) {
+				if observation.Connected == nil || *observation.Connected {
+					t.Fatalf("expected failed ping connection, got %#v", observation.Connected)
+				}
+			},
+		},
+		{
+			name:       "port failure",
+			monitoring: monitor.Monitoring{ID: "port-failed", Type: monitor.TypePort, Target: "127.0.0.1", Port: 0},
+			assert: func(t *testing.T, observation monitor.RawObservation) {
+				if observation.Connected == nil || *observation.Connected {
+					t.Fatalf("expected failed port connection, got %#v", observation.Connected)
+				}
+			},
+		},
+	}
+
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			execution, ok := r.executors.Execute(context.Background(), PhaseResponse, testCase.monitoring)
+			if !ok || execution.Response == nil {
+				t.Fatalf("expected response execution, got %#v", execution)
+			}
+			if execution.Response.Status != monitor.StatusDown {
+				t.Fatalf("expected down status, got %s", execution.Response.Status)
+			}
+			if execution.Response.ResponseTime != nil {
+				t.Fatalf("expected nil response time, got %v", *execution.Response.ResponseTime)
+			}
+			if execution.Response.Observation == nil {
+				t.Fatal("expected raw observation")
+			}
+			testCase.assert(t, *execution.Response.Observation)
+		})
+	}
+}
+
 func TestPerformHTTPRequestGETWithHeadersAndBasicAuth(t *testing.T) {
 	t.Parallel()
 
@@ -434,8 +500,8 @@ func TestHandlePingMonitoringDown(t *testing.T) {
 	if status != monitor.StatusDown {
 		t.Fatalf("expected down, got %s", status)
 	}
-	if responseTime == nil {
-		t.Fatalf("expected fallback response time")
+	if responseTime != nil {
+		t.Fatalf("expected nil response time for failed ping")
 	}
 }
 
@@ -613,7 +679,7 @@ func TestDNSRecordCheckerARecordMismatchReportsDown(t *testing.T) {
 		t.Fatalf("expected down, got %s", status)
 	}
 	if responseTime == nil {
-		t.Fatalf("expected response time")
+		t.Fatalf("expected response time for DNS mismatch")
 	}
 }
 
@@ -633,8 +699,8 @@ func TestDNSRecordCheckerMissingRecordReportsDown(t *testing.T) {
 	if status != monitor.StatusDown {
 		t.Fatalf("expected down, got %s", status)
 	}
-	if responseTime == nil {
-		t.Fatalf("expected response time")
+	if responseTime != nil {
+		t.Fatalf("expected nil response time for failed DNS lookup")
 	}
 }
 
@@ -672,8 +738,8 @@ func TestDNSRecordCheckerUnsupportedRecordTypeReportsDown(t *testing.T) {
 	if status != monitor.StatusDown {
 		t.Fatalf("expected down for unsupported record type, got %s", status)
 	}
-	if responseTime == nil {
-		t.Fatalf("expected response time")
+	if responseTime != nil {
+		t.Fatalf("expected nil response time for invalid DNS request")
 	}
 }
 

--- a/internal/adapters/runner/runner_test.go
+++ b/internal/adapters/runner/runner_test.go
@@ -501,7 +501,26 @@ func TestRunResponsePostsHTTPStatusCodeForHTTPAndKeywordMonitoring(t *testing.T)
 		if *payload.HTTPStatusCode != http.StatusCreated {
 			t.Fatalf("expected http_status_code=%d for %s, got %d", http.StatusCreated, monitoringID, *payload.HTTPStatusCode)
 		}
+		if payload.Observation == nil {
+			t.Fatalf("expected raw observation for %s", monitoringID)
+		}
+		if payload.Observation.Type != payloadType(monitoringID) {
+			t.Fatalf("expected observation type %s for %s, got %s", payloadType(monitoringID), monitoringID, payload.Observation.Type)
+		}
+		if payload.Observation.HTTPStatusCode == nil || *payload.Observation.HTTPStatusCode != http.StatusCreated {
+			t.Fatalf("expected raw HTTP status code for %s", monitoringID)
+		}
+		if payload.Observation.ResponseTime == nil {
+			t.Fatalf("expected raw response time for %s", monitoringID)
+		}
 	}
+}
+
+func payloadType(monitoringID string) monitor.Type {
+	if monitoringID == "keyword-monitoring" {
+		return monitor.TypeKeyword
+	}
+	return monitor.TypeHTTP
 }
 
 func TestRunResponsePostsDNSRecordResultWithNilHTTPStatusCode(t *testing.T) {
@@ -549,6 +568,12 @@ func TestRunResponsePostsDNSRecordResultWithNilHTTPStatusCode(t *testing.T) {
 	}
 	if payload.HTTPStatusCode != nil {
 		t.Fatalf("expected nil http_status_code for dns record response")
+	}
+	if payload.Observation == nil || payload.Observation.DNSMatched == nil || !*payload.Observation.DNSMatched {
+		t.Fatalf("expected matched DNS observation, got %#v", payload.Observation)
+	}
+	if !slices.Equal(payload.Observation.DNSObservedValues, []string{"192.0.2.10"}) {
+		t.Fatalf("unexpected observed DNS values: %#v", payload.Observation.DNSObservedValues)
 	}
 }
 

--- a/internal/domain/monitor/types.go
+++ b/internal/domain/monitor/types.go
@@ -172,10 +172,29 @@ func (m *Monitoring) UnmarshalJSON(data []byte) error {
 }
 
 type MonitoringResponsePayload struct {
-	MonitoringID   string   `json:"monitoring_id"`
-	Status         Status   `json:"status"`
-	ResponseTime   *float64 `json:"response_time"`
-	HTTPStatusCode *int     `json:"http_status_code"`
+	MonitoringID   string          `json:"monitoring_id"`
+	Status         Status          `json:"status"`
+	ResponseTime   *float64        `json:"response_time"`
+	HTTPStatusCode *int            `json:"http_status_code"`
+	Observation    *RawObservation `json:"observation,omitempty"`
+}
+
+// RawObservation contains the evidence used by Core to derive availability
+// and performance health. The legacy fields above remain populated during the
+// scanner contract migration.
+type RawObservation struct {
+	Type              Type              `json:"type"`
+	ObservedAt        time.Time         `json:"observed_at"`
+	HTTPStatusCode    *int              `json:"http_status_code,omitempty"`
+	ResponseTime      *float64          `json:"response_time,omitempty"`
+	TransportError    *string           `json:"transport_error,omitempty"`
+	Connected         *bool             `json:"connected,omitempty"`
+	KeywordMatched    *bool             `json:"keyword_matched,omitempty"`
+	DNSRecordType     string            `json:"dns_record_type,omitempty"`
+	DNSExpectedValues []string          `json:"dns_expected_values,omitempty"`
+	DNSObservedValues []string          `json:"dns_observed_values,omitempty"`
+	DNSMatched        *bool             `json:"dns_matched,omitempty"`
+	Metadata          map[string]string `json:"metadata,omitempty"`
 }
 
 type SSLResultPayload struct {


### PR DESCRIPTION
## What changed

- Add an additive `observation` payload to monitoring-response callbacks.
- Preserve the legacy `status`, `response_time`, and `http_status_code` fields.
- Capture HTTP/keyword response evidence, ping and TCP connection results, DNS observed values and match state, and stable transport-failure categories.
- Omit response-time values when a request or connection fails.
- Document the scanner observation contract and add contract and runner coverage.

## Why

WebGuard Core needs raw check evidence to derive availability and independent latency degradation while older Core versions continue reading the legacy status payload.

## Validation

- Docker full suite: `go test ./...`
- Docker formatting check: `gofmt -l .`
- Docker vet: `go vet ./...`
- Docker coverage: `go test -cover ./...`
- Docker repeated runner/health/scheduler tests: `go test -count=10 ./internal/adapters/runner ./internal/adapters/health ./internal/adapters/scheduler`
- Production image build: `docker build --target production -t webguard-instance:test .`

The race detector could not run because the provided Alpine image does not include `gcc`.

Closes #42
Related: marcel-breuer/webguard#632